### PR TITLE
Fix numa test on AMD Threadripper CPUs

### DIFF
--- a/tests/testscript.py
+++ b/tests/testscript.py
@@ -442,7 +442,7 @@ class LibvirtTests(unittest.TestCase):
         assert status == 0, "cmd failed"
         assert int(out) == 2, "Expect to find 2 sockets"
 
-        status, out = ssh(controllerVM, "lscpu | grep Thread | awk '{print $4}'")
+        status, out = ssh(controllerVM, "lscpu | grep Thread\( | awk '{print $4}'")
         assert status == 0, "cmd failed"
         assert int(out) == 2, "Expect to find 2 threads per core"
 


### PR DESCRIPTION
On a AMD Threadripper, our logic to determine the number of threads is slightly broken. 

Output of `lscpu | grep Thread | awk '{print $4}'`:

```
$ lscpu | grep Thread | awk '{print $4}'
Ryzen
2
```

Fixing this by adding the trailing `(` to the expression.

```
$ lscpu | grep Thread\( | awk '{print $4}'
2
```
