### PR TITLE
Fix testscript return code on error

### DIFF
--- a/tests/testscript.py
+++ b/tests/testscript.py
@@ -14,6 +14,7 @@ class LibvirtTests(unittest.TestCase):
     def setUpClass(cls):
         start_all()
         controllerVM.wait_for_unit("multi-user.target")
+        computeVM.wait_for_unit("multi-user.target")
         controllerVM.succeed("cp /etc/nixos.img /nfs-root/")
         controllerVM.succeed("chmod 0666 /nfs-root/nixos.img")
         controllerVM.succeed("cp /etc/cirros.img /nfs-root/")

--- a/tests/testscript.py
+++ b/tests/testscript.py
@@ -792,4 +792,5 @@ def number_of_storage_devices(machine):
 
 
 runner = unittest.TextTestRunner()
-runner.run(suite())
+if not runner.run(suite()).wasSuccessful():
+    raise Exception("Test Run unsuccessful")


### PR DESCRIPTION
Further, wait for computeVM in setup method in order to avoid problems if both VMs boot in different speed.