### PR TITLE
Increase host VMs RAM

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -21,7 +21,7 @@ pkgs.nixosTest {
 
       virtualisation = {
         cores = 4;
-        memorySize = 3072;
+        memorySize = 4096;
         interfaces = {
           eth1 = {
             vlan = 1;
@@ -73,7 +73,7 @@ pkgs.nixosTest {
 
       virtualisation = {
         cores = 4;
-        memorySize = 3072;
+        memorySize = 4096;
         interfaces = {
           eth1 = {
             vlan = 1;


### PR DESCRIPTION
We have seen some errors in the CI that might indicate some resource shortage. Increase the RAM of the VMs slightly to avoid that.