### PR TITLE
Disable virtchd restart limit in systemd

### DIFF
--- a/tests/common.nix
+++ b/tests/common.nix
@@ -153,6 +153,15 @@ in
   systemd.sockets.virtproxyd-tcp.wantedBy = [ "sockets.target" ];
   systemd.sockets.virtstoraged.wantedBy = [ "sockets.target" ];
 
+  systemd.services.virtchd = {
+      serviceConfig = {
+          Restart = "always";
+          RestartSec = 1;
+      };
+      startLimitIntervalSec = 0;
+      startLimitBurst = 0;
+  };
+
   systemd.network = {
     enable = true;
     wait-online.enable = false;


### PR DESCRIPTION
For regresstion testing, we want to restart virtchd as fast as possible. Disable the limit set by systemd to make this possible.