### PR TITLE
tests: rm CHV logs after test run

### DIFF
--- a/tests/testscript.py
+++ b/tests/testscript.py
@@ -118,8 +118,10 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
         computeVM.succeed("echo 0 > /proc/sys/vm/nr_hugepages")
 
         # Remove any remaining vm logs.
-        controllerVM.succeed("rm -f /tmp/*.log")
-        computeVM.succeed("rm -f /tmp/*.log")
+        for path in [ "/tmp/*.log",
+                      "/var/log/libvirt/ch/*.log" ]:
+            controllerVM.succeed(f"rm -f {path}")
+            computeVM.succeed(f"rm -f {path}")
 
     def test_network_hotplug_transient_vm_restart(self):
         """


### PR DESCRIPTION
Otherwise, logs only get appended to previous test run logs which makes debugging harder.

Unfortunately, it seems the libvirtd.log cannot be removed or truncated, because libvirt stops logging to it when doing so.