### PR TITLE
python: fix illegal escape

### DIFF
--- a/tests/testscript.py
+++ b/tests/testscript.py
@@ -573,7 +573,7 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
         assert status == 0, "cmd failed"
         assert int(out) == 2, "Expect to find 2 sockets"
 
-        status, out = ssh(controllerVM, "lscpu | grep Thread\( | awk '{print $4}'")
+        status, out = ssh(controllerVM, "lscpu | grep Thread\\( | awk '{print $4}'")
         assert status == 0, "cmd failed"
         assert int(out) == 2, "Expect to find 2 threads per core"
 


### PR DESCRIPTION
The following warning occurs otherwise:

```
>>> a = "lscpu | grep Thread\( | awk '{print $4}'"
<stdin>:1: SyntaxWarning: invalid escape sequence '\('
```


I've seen it in the log multiple times