### PR TITLE
flake: Use dried-nix-flakes to manage the input/outputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,6 +33,21 @@
         "type": "github"
       }
     },
+    "dried-nix-flakes": {
+      "locked": {
+        "lastModified": 1756139350,
+        "narHash": "sha256-pObQv94NclXVXjJV8sTiKwFes4fGEWpkNzDsXw5DqnY=",
+        "owner": "cyberus-technology",
+        "repo": "dried-nix-flakes",
+        "rev": "1b2ba62710c6c1d9eba0e8e3adc029cc2e9291a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cyberus-technology",
+        "repo": "dried-nix-flakes",
+        "type": "github"
+      }
+    },
     "edk2-src": {
       "flake": false,
       "locked": {
@@ -50,23 +65,6 @@
         "submodules": true,
         "type": "git",
         "url": "https://github.com/cyberus-technology/edk2"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-utils",
-        "type": "indirect"
       }
     },
     "libvirt-src": {
@@ -108,8 +106,8 @@
       "inputs": {
         "cloud-hypervisor-src": "cloud-hypervisor-src",
         "crane": "crane",
+        "dried-nix-flakes": "dried-nix-flakes",
         "edk2-src": "edk2-src",
-        "flake-utils": "flake-utils",
         "libvirt-src": "libvirt-src",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
@@ -132,21 +130,6 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }


### PR DESCRIPTION
So, what even is Dried Nix Flakes?

 - https://github.com/cyberus-technology/dried-nix-flakes

It's a pure-nix, and opinionated, tooling that aims to strip away the repetitions found in a Flake.

Namely, it removes\* all mentions of the `system` from the Flake.

\*Actually not removed, but abstracted away.

With the repetitious mentions of `system` stripped-away, the Flake is *DRY*er, as in "Don't Repeat Yourself"-er.

This fixes one of the major flaws with Flakes, where the CLI and Flake expressions both end-up having to replace the `builtins.currentSystem` value, which was deemed “impure”. The Dried Nix Flakes Flake takes the system outputs that Nixpkgs exposes by default, and automatically collapses and expands the different standard Flakes attribute sets, such that the need to use the `${system}` is removed, for the expressions.

With this change, the Flake is 1-to-1 equivalent for the systems that were exposed in the parent commit.

The only challenge with this integration is supporting the subset of platforms that the software *can* be built for. The usage of a custom `intersectAll` function is intended to allow adding more packages to that list if it ever becomes an issue, whenever the listed packages gain support for more platforms.

This fixes #47.

* * *

Checked by comparing on the commit and the parent commit:

```
~/.../libvirt/libvirt-tests $ nix-instantiate --expr '{ flake = builtins.getFlake (toString ./.); }' --attr flake.tests.x86_64-linux.default
...
/nix/store/r6zw41n964z34rkfsj16z2kj3zamcjl6-vm-test-run-Libvirt-test.drv
```

And with `nix flake check` and `nix flake check --all-systems --no-build`

Though to be fair, since we are (necessarily) using the subset of platforms that can be supported, at this point in time there is no additional platforms supported:

```
nix-repl> builtins.attrNames flake.outputs.tests
[ "x86_64-linux" ]
```