### PR TITLE
nix: slightly accelerate CHV build

### DIFF
--- a/chv.nix
+++ b/chv.nix
@@ -46,7 +46,9 @@ let
   cargoArtifacts = craneLib'.buildDepsOnly (
     commonArgs
     // {
-      pname = "cloud-hypervisor-deps";
+      # "suffix '-deps' will be appended
+      pname = "cloud-hypervisor";
+      doCheck = false;
     }
   );
 


### PR DESCRIPTION
- don't fetch test dependencies (we don't run unit tests anyway)
- prevent dependencies derivation from having "-deps-deps" suffix
