### PR TITLE
testscript: use multiple TCP connections for all* tests

### DIFF
--- a/tests/testscript.py
+++ b/tests/testscript.py
@@ -386,7 +386,7 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
         assert num_disk_controller == 1
 
         controllerVM.succeed(
-            "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p"
+            "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
         )
 
         assert wait_for_ssh(computeVM)
@@ -413,7 +413,7 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
         assert num_disk_compute == 2
 
         computeVM.succeed(
-            "virsh migrate --domain testvm --desturi ch+tcp://controllerVM/session --persistent --live --p2p"
+            "virsh migrate --domain testvm --desturi ch+tcp://controllerVM/session --persistent --live --p2p --parallel --parallel-connections 4"
         )
 
         assert wait_for_ssh(controllerVM)
@@ -484,7 +484,7 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
         assert num_devices_controller == 2
 
         controllerVM.succeed(
-            "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p"
+            "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
         )
 
         assert wait_for_ssh(computeVM)
@@ -498,7 +498,7 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
         assert number_of_network_devices(computeVM) == 1
 
         computeVM.succeed(
-            "virsh migrate --domain testvm --desturi ch+tcp://controllerVM/session --persistent --live --p2p"
+            "virsh migrate --domain testvm --desturi ch+tcp://controllerVM/session --persistent --live --p2p --parallel --parallel-connections 4"
         )
 
         assert wait_for_ssh(controllerVM)
@@ -541,7 +541,7 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
         assert int(out) == 0, "not enough huge pages are in-use"
 
         controllerVM.succeed(
-            "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p"
+            "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
         )
 
         assert wait_for_ssh(computeVM)
@@ -575,6 +575,8 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
         assert wait_for_ssh(controllerVM)
 
         controllerVM.fail(
+            # "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
+            # Currently broken when multiple threads are used and something goes wrong.
             "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p"
         )
         assert wait_for_ssh(controllerVM)
@@ -952,7 +954,7 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
         )
 
         controllerVM.succeed(
-            "virsh migrate --xml /tmp/domain-chv-serial-tcp.xml --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p"
+            "virsh migrate --xml /tmp/domain-chv-serial-tcp.xml --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
         )
         assert wait_for_ssh(computeVM)
 
@@ -987,7 +989,7 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
 
         # Do migration in a screen session and detach
         controllerVM.succeed(
-            "screen -dmS migrate virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p"
+            "screen -dmS migrate virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
         )
 
         # Wait a moment to let the migration start
@@ -995,7 +997,7 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
 
         # Check that 'virsh list' can be done without blocking
         self.assertLess(
-            measure_ms(lambda: controllerVM.succeed("virsh list | grep -q testvm")),
+            measure_ms(lambda: controllerVM.succeed("grep -q testvm < <(virsh list)")),
             1000,
             msg="Expect virsh list to execute fast",
         )
@@ -1253,7 +1255,7 @@ class LibvirtTests(PrintLogsOnErrorTestCase):
         assert int(taskset_vcpu2_controller, 16) == 0xC
 
         controllerVM.succeed(
-            "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p"
+            "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
         )
         assert wait_for_ssh(computeVM)
 


### PR DESCRIPTION
All except the base test. This reduced the total execution time by roughly 40s on my machine.