### PR TITLE
Increase number of tries before considering an operation to be failed

### DIFF
--- a/tests/testscript.py
+++ b/tests/testscript.py
@@ -1298,7 +1298,7 @@ def measure_ms(func):
 
 
 def wait_until_succeed(func):
-    retries = 200
+    retries = 600
     for i in range(retries):
         if func():
             return True


### PR DESCRIPTION
Currently, an operation is considered to fail after 20s (200 tries), when wrapped by `wait_until_succeed`. On my machine, the migration in `test_live_migration_virsh_non_blocking` needs a little more than 31s to finish and the test therefore fails. Increasing the number of tries and therefore the timeout threshold solves this issue.