### PR TITLE
flake: update to nixos-25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,16 +108,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763622513,
-        "narHash": "sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB+19M=",
+        "lastModified": 1764522689,
+        "narHash": "sha256-SqUuBFjhl/kpDiVaKLQBoD8TLD+/cTUzzgVFoaHrkqY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c58bc7f5459328e4afac201c5c4feb7c818d604b",
+        "rev": "8bb5646e0bed5dbd3ab08c7a7cc15b75ab4e1d0f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     dried-nix-flakes.url = "github:cyberus-technology/dried-nix-flakes";
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
 
     # A local path can be used for developing or testing local changes. Make
     # sure the submodules in a local libvirt checkout are populated.

--- a/tests/libvirt-test.nix
+++ b/tests/libvirt-test.nix
@@ -12,8 +12,8 @@
 let
   common = import ./common.nix { inherit libvirt-src nixos-image chv-ovmf; };
 in
-pkgs.nixosTest {
-  name = "Libvirt test";
+pkgs.testers.nixosTest {
+  name = "Libvirt test suite for Cloud Hypervisor";
 
   extraPythonPackages =
     p: with p; [


### PR DESCRIPTION
Interestingly, this reduced the size of the ISO significantly (600 + -> 520M) and I also think that the VM boot is now faster. I hadn't taken a closer look before, but now my whole test suite ran for the first time in under 10 minutes, whereas it used to take over 11.