### PR TITLE
ci: fix merge queue feature

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -22,5 +22,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade gitlint
       - name: Lint git commit messages
-        run: |
-          gitlint --commits origin/$GITHUB_BASE_REF..
+        # GITHUB_BASE_REF not available in merge queue. It is sufficient to run
+        # this check on the PR itself before the merge queue starts.
+        if: github.event_name == 'pull_request'
+        run: gitlint --commits origin/$GITHUB_BASE_REF..


### PR DESCRIPTION
Currently our merge queue is blocked because the commit lint workflow is missing the `on.merge_group` property.