### PR TITLE
Bump cloud hypervisor and fix patch file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cloud-hypervisor-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1763989972,
-        "narHash": "sha256-icCOV+oG4jppP4MVS5GW7phtiSUNGqrxYpLwjlOwsoc=",
+        "lastModified": 1764758716,
+        "narHash": "sha256-pOv2lP8qYy4w5GimEiKlILU4WVWUVykWkhXDr+22AdE=",
         "owner": "cyberus-technology",
         "repo": "cloud-hypervisor",
-        "rev": "dc905d98b7c9903a86f78a31754effe9548d335b",
+        "rev": "127f2d8f1ebfc43da697fa17a9f5f9457699fb23",
         "type": "github"
       },
       "original": {

--- a/patches/cloud-hypervisor/0001-build-chv-faster.patch
+++ b/patches/cloud-hypervisor/0001-build-chv-faster.patch
@@ -2,15 +2,12 @@ diff --git a/Cargo.toml b/Cargo.toml
 index 04b94ea9a..a2c8bd5e1 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -18,10 +18,7 @@ version = "46.0.0"
- rust-version = "1.83.0"
-
+@@ -20,7 +20,7 @@ rust-version = "1.88.0"
  [profile.release]
--codegen-units = 1
--lto = true
+ codegen-units = 1
+ lto = true
 -opt-level = "s"
--strip = true
 +opt-level = 2
 
- [profile.profiling]
- debug = true
+ # Tradeof between performance and fast compilation times for local testing and
+ # development with frequent rebuilds.


### PR DESCRIPTION
The Cargo.toml file has been edited in https://github.com/cyberus-technology/cloud-hypervisor/commit/78f1e533914d9371565794f0d4e8d202244666f4, thus we have to adjust the patch for this file.