### PR TITLE
nix: bump host VM linux to 6.17

### DIFF
--- a/tests/common.nix
+++ b/tests/common.nix
@@ -173,6 +173,7 @@ in
     environment.LSAN_OPTIONS = "report_objects=1";
   };
 
+  boot.kernelPackages = pkgs.linuxPackages_6_17;
   virtualisation.libvirtd = {
     enable = true;
     sshProxy = false;


### PR DESCRIPTION
This fixes a kernel panic that we see with Linux 6.12 when we run live migrations for a long time. We now use 6.17.