### PR TITLE
ci: quicker CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,10 @@ jobs:
           # TODO add once we have quicker CI runners
           # This
           # nix flake check
-      - name: Eval Default Test Suite
-        run: nix eval -L .#tests.x86_64-linux.default.driver
-      - name: Eval Long-Running Test Suite
-        run: nix eval -L .#tests.x86_64-linux.long_migration_with_load.driver
+      # Even `nix eval` is too slow in the GitHub CI. As long as we don't have
+      # a Nix binary cache (+ Nix git cache), we must live without this
+      # probably.
+      #- name: Eval Default Test Suite
+      #  run: nix eval -L .#tests.x86_64-linux.default.driver
+      #- name: Eval Long-Running Test Suite
+      #  run: nix eval -L .#tests.x86_64-linux.long_migration_with_load.driver


### PR DESCRIPTION
We have problems with flaky CI due to the GitHub merge queue feature. So far it is not obvious why we have so many problems with failing tests, as if we take a closer look, the job is still running but GitHub still classifies it as failing.

As pragmatic shortcut, we reduce the CI time massively at the costs of less coverage.

On-behalf-of: SAP philipp.schuster@sap.com