### PR TITLE
ci: Nix evaluate again + cache evaluation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
+      # We restore Nix evaluation and Nix tarball cache, speeding up the CI.
+      # This does not cover any Nix artifacts from the Nix store.
+      - name: Restore Nix cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/nix
+          key: nix-cache-${{ github.job }}
       # Dedicated step to separate all the
       # "copying path '/nix/store/...' from 'https://cache.nixos.org'."
       # messages from the actual build output.
@@ -42,10 +49,7 @@ jobs:
           # TODO add once we have quicker CI runners
           # This
           # nix flake check
-      # Even `nix eval` is too slow in the GitHub CI. As long as we don't have
-      # a Nix binary cache (+ Nix git cache), we must live without this
-      # probably.
-      #- name: Eval Default Test Suite
-      #  run: nix eval -L .#tests.x86_64-linux.default.driver
-      #- name: Eval Long-Running Test Suite
-      #  run: nix eval -L .#tests.x86_64-linux.long_migration_with_load.driver
+      - name: Eval Default Test Suite
+        run: nix eval -L .#tests.x86_64-linux.default.driver
+      - name: Eval Long-Running Test Suite
+        run: nix eval -L .#tests.x86_64-linux.long_migration_with_load.driver


### PR DESCRIPTION
This way we can catch more errors in CI with reasonable CI times. We still don't build as we do not have a Nix binary cache.

Example: From [5m30s](https://github.com/cyberus-technology/libvirt-tests/actions/runs/20102555632/attempts/1?pr=90) to [2m54s](https://github.com/cyberus-technology/libvirt-tests/actions/runs/20102555632?pr=90).
