### PR TITLE
ci: fix cancelled jobs in CI merge queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Build
 on:
   merge_group:
   pull_request:
-  push:
 
 concurrency:
   # Special care needs to be taken here to prevent cancelled runs in the GitHub


### PR DESCRIPTION
The CI merge queue failed again, see #89 [0].

We are using the concurrency cancellation feature in GitHub to cancel outdated
CI jobs to prevent a waste of CPU cycles. It works similar to "interruptible" in
GitLab. However, with the GitHub merge queue, this causes often weird behavior
where jobs are suddenly cancelled in the merge train.

I couldn't find proper documentation for that specific combination of features
(merge queue + concurrency group) and what fails here doesn't fail in other
projects that use these both things. In a GitHub merge queue in this project,
each job is created twice by default (as we have `on merge_group and
`on pull_request` in the CI file):

- for the PR/push itself
- for the merge queue

Currently, sometime our merge queue fails because some of these jobs are cancelled:

```
Canceling since a higher priority waiting request for Build-refs/heads/gh-readonly-queue/main/pr-89-b4aed85cf70ae7e2df098e42c352c3dd62ef9173 exists
```

To prevent cancellation, I try to switch to more distinct concurrency groups. I
didn't find proper documentation or best practices, but with some research, I came
up with this solution.

[0] https://github.com/cyberus-technology/libvirt-tests/actions/runs/20262687453/job/58178287796
