### PR TITLE
flake/chv: bump cloud-hypervisor-src + adapt to new crate structure

### DIFF
--- a/chv.nix
+++ b/chv.nix
@@ -14,31 +14,39 @@ let
   # Crane lib with proper Rust toolchain
   craneLib' = craneLib.overrideToolchain rustToolchain;
 
-  commonArgs = {
-    meta = cloud-hypervisor-meta;
-    src = craneLib'.cleanCargoSource cloud-hypervisor-src;
+  commonArgs =
+    let
+      src = craneLib'.cleanCargoSource cloud-hypervisor-src;
+    in
+    {
+      inherit src;
+      # Since Nov 2025 (v50), Cloud Hypervisor has a virtual manifest and the
+      # main package was moved into a sub directory.
+      cargoToml = "${src}/cloud-hypervisor/Cargo.toml";
 
-    # Pragmatic release profile with debug-ability and faster
-    # compilation times in mind.
-    env = {
-      CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS = "true";
-      CARGO_PROFILE_RELEASE_OPT_LEVEL = 2;
-      CARGO_PROFILE_RELEASE_OVERFLOW_CHECKS = "true";
-      CARGO_PROFILE_RELEASE_LTO = "no";
+      meta = cloud-hypervisor-meta;
 
-      # Fix build. Reference:
-      # - https://github.com/sfackler/rust-openssl/issues/1430
-      # - https://docs.rs/openssl/latest/openssl/
-      OPENSSL_NO_VENDOR = true;
+      # Pragmatic release profile with debug-ability and faster
+      # compilation times in mind.
+      env = {
+        CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS = "true";
+        CARGO_PROFILE_RELEASE_OPT_LEVEL = 2;
+        CARGO_PROFILE_RELEASE_OVERFLOW_CHECKS = "true";
+        CARGO_PROFILE_RELEASE_LTO = "no";
+
+        # Fix build. Reference:
+        # - https://github.com/sfackler/rust-openssl/issues/1430
+        # - https://docs.rs/openssl/latest/openssl/
+        OPENSSL_NO_VENDOR = true;
+      };
+
+      nativeBuildInputs = [
+        pkg-config
+      ];
+      buildInputs = [
+        openssl
+      ];
     };
-
-    nativeBuildInputs = [
-      pkg-config
-    ];
-    buildInputs = [
-      openssl
-    ];
-  };
 
   # Downloaded and compiled dependencies.
   cargoArtifacts = craneLib'.buildDepsOnly (

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cloud-hypervisor-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1765808595,
-        "narHash": "sha256-Y1VR0LVv8DUI7IHIULA7+amq8SYcY+KM/60oMqepXKQ=",
+        "lastModified": 1767714447,
+        "narHash": "sha256-d7McdQ8gp72PoeXv4TH7SNRsebB2Y1J3MyDOc6dqOew=",
         "owner": "cyberus-technology",
         "repo": "cloud-hypervisor",
-        "rev": "fa7e5145bd9730ae6d9031e8558872985b07fa4b",
+        "rev": "daaea602a21b95bbfc3c1e277e1b7145377bc561",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Since PR #7525 (Dec 2025)[0], Cloud Hypervisor uses a virtual Cargo manifest and the main package was moved to the `./cloud-hypervisor` subdirectory. This change is effective since v50. As our v49-based CHV version backported these changes already, we need to adapt the Nix build of CHV.

[0] https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7525

# Steps to Undraft
- [x] finish https://github.com/cyberus-technology/cloud-hypervisor/pull/60