### PR TITLE
ci: build and run test suite in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  checks:
+  build:
     name: Checks, Build, Lints
     runs-on: ubuntu-latest
     steps:
@@ -20,7 +20,7 @@ jobs:
       # We restore Nix evaluation and Nix tarball cache, speeding up the CI.
       # This does not cover any Nix artifacts from the Nix store.
       - name: Restore Nix cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/nix
           key: nix-cache-${{ github.job }}
@@ -42,14 +42,21 @@ jobs:
       - name: Check Spelling
         run: nix build -L .#checks.x86_64-linux.typos
       # Run all in case we forgot to add a fine-grained job.
-      - name: Check All
-        run: |
-          nix build -L .#checks.x86_64-linux.all
-          # Run all other flake-wide checks
-          # TODO add once we have quicker CI runners
-          # This
-          # nix flake check
-      - name: Eval Default Test Suite
-        run: nix eval -L .#tests.x86_64-linux.default.driver
-      - name: Eval Long-Running Test Suite
-        run: nix eval -L .#tests.x86_64-linux.long_migration_with_load.driver
+      - name: All Checks combined
+        run: nix build -L .#checks.x86_64-linux.all
+      - name: "Build Test Prerequisites: chv-ovmf"
+        run: nix build -L .#packages.x86_64-linux.chv-ovmf
+      - name: "Build Test Prerequisites: cloud-hypervisor"
+        run: nix build -L .#packages.x86_64-linux.cloud-hypervisor
+      - name: "Build Test Prerequisites: nixos-image"
+        run: nix build -L .#packages.x86_64-linux.nixos-image
+      - name: Build Default Test Suite
+        run: nix build -L .#tests.x86_64-linux.default.driver
+      - name: Build Long-Running Test Suite
+        run: nix build -L .#tests.x86_64-linux.long_migration_with_load.driver
+      - name: Run Default Test Suite
+        run: nix run -L .#tests.x86_64-linux.default.driver
+      # We run this last. This should only fail if we forgot anything important
+      # in the above lines.
+      - name: Nix flake check
+        run: nix flake check


### PR DESCRIPTION
Since our merge queue is finally working reliably [0], we should run the whole test suite as part of this repository. As long as we do not have a Nix binary cache, this is much slower than it should/could be, unfortunately. We again introduced a bug that we would have caught with these checks running in GitHubs (slow) CI [1].

[0] https://github.com/cyberus-technology/libvirt-tests/pull/93
[1] https://github.com/cyberus-technology/libvirt-tests/pull/89

