### PR TITLE
fix: workaround libvirt weirdness

### DIFF
--- a/docs/networks.md
+++ b/docs/networks.md
@@ -2,8 +2,8 @@
 
 | IP net             | Host Interface (MAC, Name)   | Host Bridge | Guest Interface (Name) | Comment                             |
 |--------------------|------------------------------|-------------|------------------------|-------------------------------------|
-| `192.168.1.0/24`   | `52:54:00:e5:b8:01`, `vnet0` | `br0`       | `eth1337`              | Main network into test VM           |
-| `192.168.2.0/24`   | `52:54:00:e5:b8:02`, `vnet1` | `br0`       | `eth1338`              | Hotplugged device (type `ethernet`) |
+| `192.168.1.0/24`   | `52:54:00:e5:b8:01`, `vtap0` | `br0`       | `eth1337`              | Main network into test VM           |
+| `192.168.2.0/24`   | `52:54:00:e5:b8:02`, `vtap1` | `br0`       | `eth1338`              | Hotplugged device (type `ethernet`) |
 | `192.168.3.0/24`   | `52:54:00:e5:b8:03`, `tap3`  | `br3`       | `eth1339`              | Hotplugged device (type `network`)  |
 | `192.168.4.0/24`   | `52:54:00:e5:b8:04`, `tap4`  | `br4`       | `eth1340`              | Hotplugged device (type `bridge`)   |
 | `192.168.100.0/24` | <dynamic>          , `eth1`  | -           | -                      | Network between host VMs            |

--- a/tests/common.nix
+++ b/tests/common.nix
@@ -152,7 +152,7 @@ let
           </disk>
           <interface type='ethernet'>
             <mac address='52:54:00:e5:b8:01'/>
-            <target dev='vnet0'/>
+            <target dev='vtap0'/>
             <model type='virtio'/>
             <driver queues='1'/>
             <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
@@ -196,7 +196,7 @@ let
     ''
       <interface type='ethernet'>
         <mac address='52:54:00:e5:b8:02'/>
-        <target dev='vnet1'/>
+        <target dev='vtap1'/>
         <model type='virtio'/>
         <driver queues='1'/>
         ${
@@ -417,7 +417,7 @@ in
       };
       "10-vnet0" = {
         # All interfaces matching this prefix are added to the bridge.
-        matchConfig.Name = "vnet*";
+        matchConfig.Name = "vtap*";
         networkConfig.Bridge = "br0";
       };
     };


### PR DESCRIPTION
If network interfaces on the host follow the naming scheme `vnet*` libvirt internal behavior prevents the proper syncing of PCI BDFs between the transient and the persistent config (as this sync relies on device names).

Before we have more clarity from a reach out to the mailing list, we workaround this libvirt weirdness.

**Now, we can merge our libvirt BDF patches for Cloud Hypervisor and the pipeline succeeds.**

