### PR TITLE
libvirt: print commit hash even in Nix derivation

### DIFF
--- a/tests/common.nix
+++ b/tests/common.nix
@@ -298,6 +298,10 @@ in
 
       # Reduce files needed to compile. We cut the build-time in half.
       mesonFlags = old.mesonFlags ++ [
+        # Helps to keep track of the commit hash in the libvirt log. Nix strips
+        # all `.git`, so we need to be explicit here.
+        "-Dcommit_hash=${libvirt-src.rev}"
+
         # Disabling tests: 1500 -> 1200
         "-Dtests=disabled"
         "-Dexpensive_tests=disabled"


### PR DESCRIPTION
This helps to figure out the exact libvirt version from a log in our CI. A small patch to the libvirt Flake is also required to make this work.

Corresponding libvirt PR:

https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/merge_requests/64