### PR TITLE
libvirt: fix print commit hash even in Nix derivation

### DIFF
--- a/tests/common.nix
+++ b/tests/common.nix
@@ -297,54 +297,56 @@ in
       dontStrip = true;
 
       # Reduce files needed to compile. We cut the build-time in half.
-      mesonFlags = old.mesonFlags ++ [
-        # Helps to keep track of the commit hash in the libvirt log. Nix strips
-        # all `.git`, so we need to be explicit here.
-        "-Dcommit_hash=${libvirt-src.rev}"
-
-        # Disabling tests: 1500 -> 1200
-        "-Dtests=disabled"
-        "-Dexpensive_tests=disabled"
-        # Disabling docs: 1200 -> 800
-        "-Ddocs=disabled"
-        # Disabling unneeded backends: 800 -> 685
-        "-Ddriver_ch=enabled"
-        "-Ddriver_qemu=disabled"
-        "-Ddriver_bhyve=disabled"
-        "-Ddriver_esx=disabled"
-        "-Ddriver_hyperv=disabled"
-        "-Ddriver_libxl=disabled"
-        "-Ddriver_lxc=disabled"
-        "-Ddriver_openvz=disabled"
-        "-Ddriver_secrets=disabled"
-        "-Ddriver_vbox=disabled"
-        "-Ddriver_vmware=disabled"
-        "-Ddriver_vz=disabled"
-        "-Dstorage_dir=disabled"
-        "-Dstorage_disk=disabled"
-        "-Dstorage_fs=enabled" # for netfs
-        "-Dstorage_gluster=disabled"
-        "-Dstorage_iscsi=disabled"
-        "-Dstorage_iscsi_direct=disabled"
-        "-Dstorage_lvm=disabled"
-        "-Dstorage_mpath=disabled"
-        "-Dstorage_rbd=disabled"
-        "-Dstorage_scsi=disabled"
-        "-Dstorage_vstorage=disabled"
-        "-Dstorage_zfs=disabled"
-        "-Dapparmor=disabled"
-        "-Dwireshark_dissector=disabled"
-        "-Dselinux=disabled"
-        "-Dsecdriver_apparmor=disabled"
-        "-Dsecdriver_selinux=disabled"
-        "-Db_sanitize=leak"
-        "-Db_sanitize=address,undefined"
-        # Enabling the sanitizers has led to warnings about inlining macro
-        # generated cleanup methods of the glib which spam the build log.
-        # Ignoring and suppressing the warnings seems like the only option.
-        # "warning: inlining failed in call to 'glib_autoptr_cleanup_virNetlinkMsg': call is unlikely and code size would grow [-Winline]"
-        "-Dc_args=-Wno-inline"
-      ];
+      mesonFlags =
+        old.mesonFlags
+        ++
+          # Helps to keep track of the commit hash in the libvirt log. Nix strips
+          # all `.git`, so we need to be explicit here.
+          lib.optional (libvirt-src ? rev) "-Dcommit_hash=${libvirt-src.rev}"
+        ++ [
+          # Disabling tests: 1500 -> 1200
+          "-Dtests=disabled"
+          "-Dexpensive_tests=disabled"
+          # Disabling docs: 1200 -> 800
+          "-Ddocs=disabled"
+          # Disabling unneeded backends: 800 -> 685
+          "-Ddriver_ch=enabled"
+          "-Ddriver_qemu=disabled"
+          "-Ddriver_bhyve=disabled"
+          "-Ddriver_esx=disabled"
+          "-Ddriver_hyperv=disabled"
+          "-Ddriver_libxl=disabled"
+          "-Ddriver_lxc=disabled"
+          "-Ddriver_openvz=disabled"
+          "-Ddriver_secrets=disabled"
+          "-Ddriver_vbox=disabled"
+          "-Ddriver_vmware=disabled"
+          "-Ddriver_vz=disabled"
+          "-Dstorage_dir=disabled"
+          "-Dstorage_disk=disabled"
+          "-Dstorage_fs=enabled" # for netfs
+          "-Dstorage_gluster=disabled"
+          "-Dstorage_iscsi=disabled"
+          "-Dstorage_iscsi_direct=disabled"
+          "-Dstorage_lvm=disabled"
+          "-Dstorage_mpath=disabled"
+          "-Dstorage_rbd=disabled"
+          "-Dstorage_scsi=disabled"
+          "-Dstorage_vstorage=disabled"
+          "-Dstorage_zfs=disabled"
+          "-Dapparmor=disabled"
+          "-Dwireshark_dissector=disabled"
+          "-Dselinux=disabled"
+          "-Dsecdriver_apparmor=disabled"
+          "-Dsecdriver_selinux=disabled"
+          "-Db_sanitize=leak"
+          "-Db_sanitize=address,undefined"
+          # Enabling the sanitizers has led to warnings about inlining macro
+          # generated cleanup methods of the glib which spam the build log.
+          # Ignoring and suppressing the warnings seems like the only option.
+          # "warning: inlining failed in call to 'glib_autoptr_cleanup_virNetlinkMsg': call is unlikely and code size would grow [-Winline]"
+          "-Dc_args=-Wno-inline"
+        ];
     });
   };
 


### PR DESCRIPTION
We need to add a patch to libvirt to unconditionally add the `rev` attribute in all cases. Currently, we cannot bump libvirt-tests in libvirt, however.

This makes libvirt-tests more flexible.

On-behalf-of: SAP philipp.schuster@sap.com