### PR TITLE
python/ci: add Python type check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
         run: nix build -L .#checks.x86_64-linux.pythonFormat
       - name: Check Python Lints
         run: nix build -L .#checks.x86_64-linux.pythonLint
+      - name: Check Python Types
+        run: nix build -L .#checks.x86_64-linux.pythonTypes
       - name: Check Spelling
         run: nix build -L .#checks.x86_64-linux.typos
       # Run all in case we forgot to add a fine-grained job.
@@ -47,7 +49,6 @@ jobs:
           nix build -L .#checks.x86_64-linux.all
           # Run all other flake-wide checks
           # TODO add once we have quicker CI runners
-          # This
           # nix flake check
       - name: Eval Default Test Suite
         run: nix eval -L .#tests.x86_64-linux.default.driver

--- a/flake.nix
+++ b/flake.nix
@@ -141,6 +141,15 @@
                   ruff check ./tests
                   mkdir $out
                 '';
+            pythonTypes =
+              pkgs.runCommand "python-types"
+                {
+                  nativeBuildInputs = with pkgs; [ pyright ];
+                }
+                ''
+                  pyright ${cleanSrc}/tests
+                  mkdir $out
+                '';
             typos =
               pkgs.runCommand "spellcheck"
                 {
@@ -167,6 +176,7 @@
               deadnix
               pythonFormat
               pythonLint
+              pythonTypes
               typos
               ;
             default = all;

--- a/tests/testscript.py
+++ b/tests/testscript.py
@@ -6,6 +6,8 @@ import time
 import unittest
 import weakref
 
+# pyright: reportPossiblyUnboundVariable=false
+
 # Following is required to allow proper linting of the python code in IDEs.
 # Because certain functions like start_all() and certain objects like computeVM
 # or other machines are added by Nix, we need to provide certain stub objects
@@ -85,7 +87,8 @@ class CommandGuard:
         :param machine: Virtual machine to send the command from
         :type machine: Machine
         """
-        self._finilizer = weakref.finalize(self, command, machine)
+
+        self._finilizer = weakref.finalize(self, command, machine)  # pyright: ignore[reportCallIssue]
 
     def __enter__(self):
         return self

--- a/tests/testscript_long_migration_with_load.py
+++ b/tests/testscript_long_migration_with_load.py
@@ -1,6 +1,8 @@
 import time
 import unittest
 
+# pyright: reportPossiblyUnboundVariable=false
+
 # Following is required to allow proper linting of the python code in IDEs.
 # Because certain functions like start_all() and certain objects like computeVM
 # or other machines are added by Nix, we need to provide certain stub objects


### PR DESCRIPTION
We started to use more and more typings. This doesn't force you to write typings but enforces them where they are available.

Typings are a great developer experience improvement in IDEs with Python
support.


For a specific example what we are gaining here, see https://github.com/cyberus-technology/libvirt-tests/pull/122#issuecomment-3754640541