### PR TITLE
flake: bump cloud hypervisor and adjust source filter

### DIFF
--- a/chv.nix
+++ b/chv.nix
@@ -14,9 +14,16 @@ let
   # Crane lib with proper Rust toolchain
   craneLib' = craneLib.overrideToolchain rustToolchain;
 
+  jsonFilter = path: _type: builtins.match ".*json$" path != null;
+  sourceFilter = path: type: (jsonFilter path type) || (craneLib.filterCargoSources path type);
+
   commonArgs =
     let
-      src = craneLib'.cleanCargoSource cloud-hypervisor-src;
+      src = lib.cleanSourceWith {
+        src = cloud-hypervisor-src;
+        filter = sourceFilter;
+        name = "source";
+      };
     in
     {
       inherit src;

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cloud-hypervisor-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1768228722,
-        "narHash": "sha256-FKhFxeCULCsirfH9W/lQtHOWOxpcMOY5a8sfyEB++m0=",
+        "lastModified": 1768559181,
+        "narHash": "sha256-5OHc7Rm0UbuDe5E6h8iSVjmdss9VhKUrouKvKwlEnYg=",
         "owner": "cyberus-technology",
         "repo": "cloud-hypervisor",
-        "rev": "75efbe171ae8de4e8724b2c83d0754e7aaf04efe",
+        "rev": "d8066c9934b0f040a37ca0365c83ff5b25ccaa49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Cloud Hypervisor now has CPU profiles in json files. This change bumps Cloud Hypervisor to the version that introduces said CPU profiles, and adjusts the source filter to also include the json files.