### PR TITLE
flake: Bump libvirt-src

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
     "libvirt-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1768818406,
-        "narHash": "sha256-V+dX4oNJx57GdLLzQM5oqMkupWaobZDZQury8R5LrLA=",
+        "lastModified": 1769089136,
+        "narHash": "sha256-2LcHuW3KRaDD6FdYy2w3/6ID2vHYXHN7c2scrxfw3zM=",
         "ref": "gardenlinux",
-        "rev": "3d460ccc665801e2a6888884cd06ccca9422de70",
-        "revCount": 53580,
+        "rev": "58478b8dd4c5576c20ad9fc05482a8e74fb649c3",
+        "revCount": 53586,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/cyberus-technology/libvirt"


### PR DESCRIPTION
Bump libvirt-src to a version that includes CPU the profile interface.
