### PR TITLE
flake: fix very unfortunate Nix+Python developer inconvenience

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -208,6 +208,28 @@
           packages = with pkgs; [
             gitlint
           ];
+          shellHook =
+            # We need our `test_helper` Python library for the NixOS integration
+            # tests, which are Python projects themselves. For this reason, we
+            # assemble a Python toolchain that includes this package. We however
+            # also want full convenience for local development flows.
+            #
+            # The very same Nix Python toolchain is also used by the Nix
+            # development shell. When developers run `nix run #<test>.driver`,
+            # the Python process executes in the host environment of the caller
+            # and resolves modules via `PYTHONPATH` - from the caller who might
+            # have opened a Nix development shell. In that situation,
+            # `test_helper` will be imported from the likely outdated location
+            # in PYTHONPATH rather than from the local (potentially modified)
+            # files.
+            #
+            # This results in a confusing and very poor developer experience
+            # where an outdated version of `test_helper` is used even though
+            # local changes exist. To ensure the local version always takes
+            # precedence, we explicitly prepend the local path to `PYTHONPATH`.
+            ''
+              export PYTHONPATH=$PWD/test_helper/test_helper:$PYTHONPATH
+            '';
         };
         packages = {
           # Export of the overlay'ed package


### PR DESCRIPTION
flake: fix very unfortunate Nix+Python developer inconvenience

# Problem

This only affects users of the Nix development shell!

Since [0], we package our "test_helper" Python library in Nix. This is
an input of the Nix flake check `pythonTypes`. Python inside this
derivation will find the "test_helper" package via the PYTHONPATH
environment variable. In our development shell, we use

inputsFrom = builtins.attrValues self.checks;

which brings that very library into scope - including PYTHONPATH - BOOM!

As we run the integration tests, which are bash scripts invoking Python,
in the host context, Python will see PYTHONPATH from the host. This causes
situations where the test uses an old version of the "test_helper"
library and new local changes aren't effective.

This is confusing, was hard to debug, and causes unbearable inconvenience.
However, we do not have any bug here but just an unfortunate combination of
things.

The proper solution is to modify PYTHONPATH in the shellHook of the
dev shell to always point to the local version of the library.

## Verify

One can verify that Python indeed uses the variable by using:

__init__.py:
```
from .test_helper import (
    hello
)

__all__ = [
    "hello"
]
```

test_helper.py:
```
def hello():
    print("hello")
```

Python repl:
```
$ python
import test_helper as th
th.hello()
```

[0] https://github.com/cyberus-technology/libvirt-tests/pull/137

On-behalf-of: SAP philipp.schuster@sap.com
Signed-off-by: Philipp Schuster <philipp.schuster@cyberus-technology.de>