### PR TITLE
flake: bump libvirt and cloud-hypervisor

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1770215234,
-        "narHash": "sha256-Nhol/EzUJGcPGUwBtdvOEF9fvRc1oSvMkiSPM41PDOo=",
+        "lastModified": 1770798639,
+        "narHash": "sha256-ze3ZuHDbCahaEZCOL8QWa81W1V+O7RBPrZDf83/KVuo=",
         "owner": "cyberus-technology",
         "repo": "cloud-hypervisor",
-        "rev": "332a4bc5d64bccab7eb87e45536bd22b7e4ed4b1",
+        "rev": "409b4affe32ac1ae9a6f4c42793c59099d76ecbd",
         "type": "github"
       },
       "original": {
@@ -193,11 +193,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770625785,
-        "narHash": "sha256-cgFg5Q2SejgCK9GKPs7ppoAqnvrpaibvlbRkhfpR/Ic=",
+        "lastModified": 1770808379,
+        "narHash": "sha256-EjP8Wrp27kCTNZOiDiKmzi/ssgS/fD+8nQo6vRfwRt0=",
         "ref": "gardenlinux",
-        "rev": "4c2c91ea939f009990db1b72e55bd6663bcfb764",
-        "revCount": 53615,
+        "rev": "be575f7b06806e84aec56bf531e7029a1d44dd01",
+        "revCount": 53623,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/cyberus-technology/libvirt"
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770623548,
-        "narHash": "sha256-5dVoRcGRLApPBfy6LejgrNPoK08y4TwUIl3bF4Tb4eU=",
+        "lastModified": 1770807650,
+        "narHash": "sha256-3VnSEJQQZy/069/CfuqrXaEd3KEHdqLOnMSC67275YA=",
         "owner": "cyberus-technology",
         "repo": "libvirt-tests",
-        "rev": "d983b95e2395a0a6481f5ca50bf0b585eda28ede",
+        "rev": "2c3565fe66d4dcdb2ff7d029f18090d0522d71f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the libvirt and cloud-hypervisor after SMBIOS changes.