### PR TITLE
tests: add context to self.assert* methods

### DIFF
--- a/tests/testsuite_default.py
+++ b/tests/testsuite_default.py
@@ -92,7 +92,11 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
 
         controllerVM.succeed("virsh start testvm")
         wait_for_ssh(controllerVM)
-        self.assertEqual(number_of_network_devices(controllerVM), num_net_devices_old)
+        self.assertEqual(
+            number_of_network_devices(controllerVM),
+            num_net_devices_old,
+            "number of network devices should match",
+        )
 
     def test_network_hotplug_persistent_vm_restart(self):
         """
@@ -120,7 +124,9 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         controllerVM.succeed("virsh start testvm")
         wait_for_ssh(controllerVM)
         self.assertEqual(
-            number_of_network_devices(controllerVM), num_net_devices_old + 1
+            number_of_network_devices(controllerVM),
+            num_net_devices_old + 1,
+            "number of network devices should match",
         )
 
     def test_network_hotplug_persistent_transient_detach_vm_restart(self):
@@ -145,16 +151,28 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         )
 
         num_net_devices_new = number_of_network_devices(controllerVM)
-        self.assertEqual(num_net_devices_new, num_net_devices_old + 1)
+        self.assertEqual(
+            num_net_devices_new,
+            num_net_devices_old + 1,
+            "number of network devices should match",
+        )
 
         # Transiently detach the device. It should re-appear when the VM is restarted.
         hotplug(controllerVM, "virsh detach-device testvm /etc/new_interface.xml")
-        self.assertEqual(number_of_network_devices(controllerVM), num_net_devices_old)
+        self.assertEqual(
+            number_of_network_devices(controllerVM),
+            num_net_devices_old,
+            "number of network devices should match",
+        )
 
         controllerVM.succeed("virsh destroy testvm")
         controllerVM.succeed("virsh start testvm")
         wait_for_ssh(controllerVM)
-        self.assertEqual(number_of_network_devices(controllerVM), num_net_devices_new)
+        self.assertEqual(
+            number_of_network_devices(controllerVM),
+            num_net_devices_new,
+            "number of network devices should match",
+        )
 
     def test_network_hotplug_attach_detach_transient(self):
         """
@@ -172,7 +190,11 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
 
         hotplug(controllerVM, "virsh attach-device testvm /etc/new_interface.xml")
         hotplug(controllerVM, "virsh detach-device testvm /etc/new_interface.xml")
-        self.assertEqual(number_of_network_devices(controllerVM), num_devices_old)
+        self.assertEqual(
+            number_of_network_devices(controllerVM),
+            num_devices_old,
+            "number of network devices should match",
+        )
 
     def test_network_hotplug_attach_detach_persistent(self):
         """
@@ -196,7 +218,11 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             controllerVM,
             "virsh detach-device --persistent testvm /etc/new_interface.xml",
         )
-        self.assertEqual(number_of_network_devices(controllerVM), num_devices_old)
+        self.assertEqual(
+            number_of_network_devices(controllerVM),
+            num_devices_old,
+            "number of network devices should match",
+        )
 
     def test_hotplug(self):
         """
@@ -557,8 +583,12 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         )
         disk_size_host = controllerVM.succeed("ls /tmp/disk.img -l | awk '{print $5}'")
 
-        self.assertEqual(int(disk_size_guest), disk_size_bytes_100M)
-        self.assertEqual(int(disk_size_host), disk_size_bytes_100M)
+        self.assertEqual(
+            int(disk_size_guest), disk_size_bytes_100M, "guest disk size should match"
+        )
+        self.assertEqual(
+            int(disk_size_host), disk_size_bytes_100M, "host disk size should match"
+        )
 
         # Use full file path instead of virtual device name here because both should work with --path
         controllerVM.succeed(
@@ -570,8 +600,12 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         )
         disk_size_host = controllerVM.succeed("ls /tmp/disk.img -l | awk '{print $5}'")
 
-        self.assertEqual(int(disk_size_guest), disk_size_bytes_10M)
-        self.assertEqual(int(disk_size_host), disk_size_bytes_10M)
+        self.assertEqual(
+            int(disk_size_guest), disk_size_bytes_10M, "guest disk size should match"
+        )
+        self.assertEqual(
+            int(disk_size_host), disk_size_bytes_10M, "host disk size should match"
+        )
 
         # Use virtual device name as --path
         controllerVM.succeed(
@@ -583,8 +617,12 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         )
         disk_size_host = controllerVM.succeed("ls /tmp/disk.img -l | awk '{print $5}'")
 
-        self.assertEqual(int(disk_size_guest), disk_size_bytes_200M)
-        self.assertEqual(int(disk_size_host), disk_size_bytes_200M)
+        self.assertEqual(
+            int(disk_size_guest), disk_size_bytes_200M, "guest disk size should match"
+        )
+        self.assertEqual(
+            int(disk_size_host), disk_size_bytes_200M, "host disk size should match"
+        )
 
         # Use bytes instead of KiB
         controllerVM.succeed(
@@ -596,8 +634,12 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         )
         disk_size_host = controllerVM.succeed("ls /tmp/disk.img -l | awk '{print $5}'")
 
-        self.assertEqual(int(disk_size_guest), disk_size_bytes_100M)
-        self.assertEqual(int(disk_size_host), disk_size_bytes_100M)
+        self.assertEqual(
+            int(disk_size_guest), disk_size_bytes_100M, "guest disk size should match"
+        )
+        self.assertEqual(
+            int(disk_size_host), disk_size_bytes_100M, "host disk size should match"
+        )
 
         # Changing to capacity must fail and not change the disk size because it
         # is not supported for file-based disk images.
@@ -608,8 +650,12 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         )
         disk_size_host = controllerVM.succeed("ls /tmp/disk.img -l | awk '{print $5}'")
 
-        self.assertEqual(int(disk_size_guest), disk_size_bytes_100M)
-        self.assertEqual(int(disk_size_host), disk_size_bytes_100M)
+        self.assertEqual(
+            int(disk_size_guest), disk_size_bytes_100M, "guest disk size should match"
+        )
+        self.assertEqual(
+            int(disk_size_host), disk_size_bytes_100M, "host disk size should match"
+        )
 
     def test_disk_is_locked(self):
         """
@@ -668,7 +714,9 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             controllerVM, "lsblk --raw -b /dev/vdb | awk '{print $4}' | tail -n1"
         )
 
-        self.assertEqual(int(disk_size_guest), disk_size_bytes_100M)
+        self.assertEqual(
+            int(disk_size_guest), disk_size_bytes_100M, "guest disk size should match"
+        )
 
         controllerVM.fail(
             f"virsh blockresize --domain testvm --path vdb --size {disk_size_bytes_10M // 1024}"
@@ -719,7 +767,11 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         wait_for_ssh(controllerVM)
 
         devices_after = pci_devices_by_bdf(controllerVM)
-        self.assertEqual(devices_after, devices_before)
+        self.assertEqual(
+            devices_after,
+            devices_before,
+            "devices should match after detach and restart",
+        )
 
     def test_bdf_domain_defs_in_sync_after_transient_unplug(self):
         """
@@ -776,6 +828,7 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         self.assertEqual(
             devices_persistent_vdb_added.get(new_bdf_vdb),
             devices_transient.get(new_bdf_vdb),
+            f"device at BDF {new_bdf_vdb} should match in transient and persistent config",
         )
         # Remove transient. The device is removed from the transient domain definition but not from the persistent
         # one. The transient domain definition has to mark the BDF as still in use nevertheless.
@@ -783,7 +836,10 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         devices_transient = parse_devices_from_dom_def(
             controllerVM, DOMAIN_DEF_TRANSIENT_PATH
         )
-        self.assertIsNone(devices_transient.get(new_bdf_vdb))
+        self.assertIsNone(
+            devices_transient.get(new_bdf_vdb),
+            f"no device should exist at BDF {new_bdf_vdb}",
+        )
         # Attach another device persistently. If we did not respect in the transient domain definition that the disk
         # we detached before is still present in persistent domain definition, then we now try to assign
         # `new_bdf_vdb` twice in the persistent domain definition. In other words: Persistent and transient domain
@@ -809,7 +865,11 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             controllerVM, DOMAIN_DEF_TRANSIENT_PATH
         )
         for bdf in bdf_new_devices:
-            self.assertEqual(devices_transient.get(bdf), devices_persistent.get(bdf))
+            self.assertEqual(
+                devices_transient.get(bdf),
+                devices_persistent.get(bdf),
+                "devices should match in transient and persistent config",
+            )
 
     def test_bdf_domain_defs_in_sync_after_transient_hotplug(self):
         """
@@ -854,7 +914,10 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
                 set(devices_transient_before.keys())
             )
         )[0]
-        self.assertIsNone(devices_persistent.get(new_bdf_transient))
+        self.assertIsNone(
+            devices_persistent.get(new_bdf_transient),
+            f"no device should exist at BDF {new_bdf_transient}",
+        )
 
         # Attach another device persistently. If we did not respect in the persistent definition that the disk we
         # attached before is still present in transient definition, then we now try to assign the BDF of the disk
@@ -888,7 +951,9 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         # And make sure that the exact same devices share the same BDF in transient and persistent definitions
         for bdf in bdf_new_devices:
             self.assertEqual(
-                devices_transient_end.get(bdf), devices_persistent_end.get(bdf)
+                devices_transient_end.get(bdf),
+                devices_persistent_end.get(bdf),
+                "devices should match in transient and persistent config",
             )
 
     def test_libvirt_default_net_prefix_triggers_desynchronizing(self):
@@ -1016,10 +1081,11 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         domcapabilities_out = controllerVM.succeed("virsh domcapabilities")
 
         for model in expected_cpu_models:
-            self.assertIn(model, cpu_models_out)
+            self.assertIn(model, cpu_models_out, "should report supported CPU model")
             self.assertIn(
                 f"<model usable='yes' vendor='Intel' canonical='{model}'>{model}</model>",
                 domcapabilities_out,
+                "should report supported CPU model",
             )
 
     def test_list_smbios_biosinfo(self):
@@ -1042,7 +1108,7 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
                 controllerVM,
                 f"dmidecode --string {dmi_string} | tr -d '\\n'",
             )
-            self.assertEqual(expected, actual)
+            self.assertEqual(expected, actual, "smbios biosinfo should match")
 
     def test_list_smbios_sysinfo(self):
         """
@@ -1073,13 +1139,17 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
                 controllerVM,
                 f"dmidecode --string {dmi_string} | tr -d '\\n'",
             )
-            self.assertEqual(expected, actual)
+            self.assertEqual(expected, actual, "smbios sysinfo should match")
 
         actual = ssh(
             controllerVM,
             "cat /sys/devices/virtual/dmi/id/chassis_asset_tag | tr -d '\\n'",
         )
-        self.assertEqual(expected_field_values["chassis-asset-tag"], actual)
+        self.assertEqual(
+            expected_field_values["chassis-asset-tag"],
+            actual,
+            "smbios chassis should match",
+        )
 
     def test_list_smbios_host(self):
         """
@@ -1114,7 +1184,7 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
                 controllerVM,
                 f"dmidecode --string {dmi_string} | tr -d '\\n'",
             )
-            self.assertEqual(expected, actual)
+            self.assertEqual(expected, actual, "smbios string should match")
 
     def test_list_smbios_oem_strings(self):
         """
@@ -1133,7 +1203,7 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
 
         oem_strings_out = ssh(controllerVM, "dmidecode -t 11 --quiet")
         for expected in expected_oem_strings:
-            self.assertIn(expected, oem_strings_out)
+            self.assertIn(expected, oem_strings_out, "should have smbios OEM string")
 
     def test_suspend_resume(self):
         """
@@ -1148,13 +1218,13 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         out = controllerVM.succeed(
             "virsh list --all | grep testvm | awk '{print $3}'"
         ).strip()
-        self.assertEqual(out, "paused")
+        self.assertEqual(out, "paused", "domain state should match")
 
         controllerVM.succeed("virsh resume testvm")
         out = controllerVM.succeed(
             "virsh list --all | grep testvm | awk '{print $3}'"
         ).strip()
-        self.assertEqual(out, "running")
+        self.assertEqual(out, "running", "domain state should match")
         wait_for_ssh(controllerVM)
 
     def test_reboot_guestinduced(self):

--- a/tests/testsuite_migration.py
+++ b/tests/testsuite_migration.py
@@ -88,10 +88,14 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         hotplug(controllerVM, "virsh attach-device testvm /etc/new_interface.xml")
 
         num_devices_controller = number_of_network_devices(controllerVM)
-        self.assertEqual(num_devices_controller, 2)
+        self.assertEqual(
+            num_devices_controller, 2, "number of network devices should match"
+        )
 
         num_disk_controller = number_of_storage_devices(controllerVM)
-        self.assertEqual(num_disk_controller, 1)
+        self.assertEqual(
+            num_disk_controller, 1, "number of storage devices should match"
+        )
 
         controllerVM.succeed(
             "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
@@ -100,7 +104,9 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         wait_for_ssh(computeVM)
 
         num_devices_compute = number_of_network_devices(computeVM)
-        self.assertEqual(num_devices_compute, 2)
+        self.assertEqual(
+            num_devices_compute, 2, "number of network devices should match"
+        )
 
         controllerVM.succeed("systemctl restart virtchd")
         computeVM.succeed("systemctl restart virtchd")
@@ -115,10 +121,12 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         )
 
         num_devices_compute = number_of_network_devices(computeVM)
-        self.assertEqual(num_devices_compute, 1)
+        self.assertEqual(
+            num_devices_compute, 1, "number of network devices should match"
+        )
 
         num_disk_compute = number_of_storage_devices(computeVM)
-        self.assertEqual(num_disk_compute, 2)
+        self.assertEqual(num_disk_compute, 2, "number of storage devices should match")
 
         computeVM.succeed(
             "virsh migrate --domain testvm --desturi ch+tcp://controllerVM/session --persistent --live --p2p --parallel --parallel-connections 4"
@@ -135,7 +143,7 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         hotplug(controllerVM, "virsh detach-disk --domain testvm --target vdb")
 
         num_disk_compute = number_of_storage_devices(controllerVM)
-        self.assertEqual(num_disk_compute, 1)
+        self.assertEqual(num_disk_compute, 1, "number of storage devices should match")
 
     def test_live_migration(self):
         """
@@ -192,7 +200,7 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
 
             # We only check whether we got rarp packets for both NICs, by
             # looking at the source MAC addresses.
-            self.assertEqual(len(set(rarps)), 2)
+            self.assertEqual(len(set(rarps)), 2, "number of rarp packets should match")
 
         for _ in range(2):
             start_capture(computeVM)
@@ -237,7 +245,9 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         )
 
         num_devices_controller = number_of_network_devices(controllerVM)
-        self.assertEqual(num_devices_controller, 2)
+        self.assertEqual(
+            num_devices_controller, 2, "number of network devices should match"
+        )
 
         controllerVM.succeed(
             "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
@@ -246,22 +256,38 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         wait_for_ssh(computeVM)
 
         num_devices_compute = number_of_network_devices(computeVM)
-        self.assertEqual(num_devices_controller, num_devices_compute)
+        self.assertEqual(
+            num_devices_controller,
+            num_devices_compute,
+            "number of network devices should match",
+        )
         hotplug(computeVM, "virsh detach-device testvm /etc/new_interface.xml")
-        self.assertEqual(number_of_network_devices(computeVM), 1)
+        self.assertEqual(
+            number_of_network_devices(computeVM),
+            1,
+            "number of network devices should match",
+        )
 
         computeVM.succeed(
             "virsh migrate --domain testvm --desturi ch+tcp://controllerVM/session --persistent --live --p2p --parallel --parallel-connections 4"
         )
 
         wait_for_ssh(controllerVM)
-        self.assertEqual(number_of_network_devices(controllerVM), 1)
+        self.assertEqual(
+            number_of_network_devices(controllerVM),
+            1,
+            "number of network devices should match",
+        )
 
         controllerVM.succeed("virsh destroy testvm")
 
         controllerVM.succeed("virsh start testvm")
         wait_for_ssh(controllerVM)
-        self.assertEqual(number_of_network_devices(controllerVM), 2)
+        self.assertEqual(
+            number_of_network_devices(controllerVM),
+            2,
+            "number of network devices should match",
+        )
 
     def test_live_migration_with_serial_tcp(self):
         """
@@ -388,7 +414,11 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             'grep -c "Spawned thread to send VM memory" /var/log/libvirt/ch/testvm.log'
         ).strip()
 
-        self.assertEqual(parallel_connections, int(num_threads))
+        self.assertEqual(
+            parallel_connections,
+            int(num_threads),
+            "number of parallel connections should match threads",
+        )
 
     def test_live_migration_with_vcpu_pinning(self):
         """
@@ -416,8 +446,12 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             f"taskset -p {tid_vcpu2_controller} | awk '{{print $6}}'"
         ).rstrip()
 
-        self.assertEqual(int(taskset_vcpu0_controller, 16), 0x3)
-        self.assertEqual(int(taskset_vcpu2_controller, 16), 0xC)
+        self.assertEqual(
+            int(taskset_vcpu0_controller, 16), 0x3, "vCPU taskset should match"
+        )
+        self.assertEqual(
+            int(taskset_vcpu2_controller, 16), 0xC, "vCPU taskset should match"
+        )
 
         controllerVM.succeed(
             "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
@@ -441,10 +475,14 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         ).rstrip()
 
         self.assertEqual(
-            int(taskset_vcpu0_controller, 16), int(taskset_vcpu0_compute, 16)
+            int(taskset_vcpu0_controller, 16),
+            int(taskset_vcpu0_compute, 16),
+            "vCPU taskset should match",
         )
         self.assertEqual(
-            int(taskset_vcpu2_controller, 16), int(taskset_vcpu2_compute, 16)
+            int(taskset_vcpu2_controller, 16),
+            int(taskset_vcpu2_compute, 16),
+            "vCPU taskset should match",
         )
 
     def test_live_migration_kill_chv_on_sender_side(self):
@@ -563,8 +601,12 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
                     set(server_hello)
                 )  # creating a set will discard duplicates.
 
-                self.assertEqual(server_hellos, expected)
-                self.assertEqual(tcp_streams, expected)
+                self.assertEqual(
+                    server_hellos, expected, "number of server_hellos should match"
+                )
+                self.assertEqual(
+                    tcp_streams, expected, "number of tcp_streams should match"
+                )
                 wait_for_ssh(dst)
 
     def test_live_migration_tls_without_certificates(self):
@@ -701,28 +743,57 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
 
         devices = pci_devices_by_bdf(controllerVM)
         # Implicitly added fixed to 0x01
-        self.assertEqual(devices["00:01.0"], VIRTIO_ENTROPY_SOURCE)
+        self.assertEqual(
+            devices["00:01.0"],
+            VIRTIO_ENTROPY_SOURCE,
+            "device type at BDF 00:01.0 should match",
+        )
         # Added by XML; dynamic BDF
-        self.assertEqual(devices["00:02.0"], VIRTIO_NETWORK_DEVICE)
+        self.assertEqual(
+            devices["00:02.0"],
+            VIRTIO_NETWORK_DEVICE,
+            "device type at BDF 00:02.0 should match",
+        )
         # Add through XML
-        self.assertEqual(devices["00:03.0"], VIRTIO_BLOCK_DEVICE)
+        self.assertEqual(
+            devices["00:03.0"],
+            VIRTIO_BLOCK_DEVICE,
+            "device type at BDF 00:03.0 should match",
+        )
         # Defined fixed BDF in XML; Hotplugged
-        self.assertEqual(devices["00:04.0"], VIRTIO_NETWORK_DEVICE)
+        self.assertEqual(
+            devices["00:04.0"],
+            VIRTIO_NETWORK_DEVICE,
+            "device type at BDF 00:04.0 should match",
+        )
         # Hotplugged by this test (vdb)
-        self.assertEqual(devices["00:05.0"], VIRTIO_BLOCK_DEVICE)
+        self.assertEqual(
+            devices["00:05.0"],
+            VIRTIO_BLOCK_DEVICE,
+            "device type at BDF 00:05.0 should match",
+        )
         # Hotplugged by this test (vdc)
-        self.assertEqual(devices["00:06.0"], VIRTIO_BLOCK_DEVICE)
+        self.assertEqual(
+            devices["00:06.0"],
+            VIRTIO_BLOCK_DEVICE,
+            "device type at BDF 00:06.0 should match",
+        )
 
         # Check that we can reuse the same non-statically allocated BDF
         hotplug(controllerVM, "virsh detach-disk --domain testvm --target vdb")
 
-        self.assertIsNone(pci_devices_by_bdf(controllerVM).get("00:05.0"))
+        self.assertIsNone(
+            pci_devices_by_bdf(controllerVM).get("00:05.0"),
+            "no device should exist at BDF 00:05.0",
+        )
         hotplug(
             controllerVM,
             "virsh attach-disk --domain testvm --target vdb --source /var/lib/libvirt/storage-pools/nfs-share/vdb.img",
         )
         self.assertEqual(
-            pci_devices_by_bdf(controllerVM).get("00:05.0"), VIRTIO_BLOCK_DEVICE
+            pci_devices_by_bdf(controllerVM).get("00:05.0"),
+            VIRTIO_BLOCK_DEVICE,
+            "device type at BDF 00:05.0 should match",
         )
 
         # We free slot 4 and 5 ...
@@ -731,8 +802,14 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             "virsh detach-device testvm /etc/new_interface_explicit_bdf.xml",
         )
         hotplug(controllerVM, "virsh detach-disk --domain testvm --target vdb")
-        self.assertIsNone(pci_devices_by_bdf(controllerVM).get("00:04.0"))
-        self.assertIsNone(pci_devices_by_bdf(controllerVM).get("00:05.0"))
+        self.assertIsNone(
+            pci_devices_by_bdf(controllerVM).get("00:04.0"),
+            "no device should exist at BDF 00:04.0",
+        )
+        self.assertIsNone(
+            pci_devices_by_bdf(controllerVM).get("00:05.0"),
+            "no device should exist at BDF 00:05.0",
+        )
         # ...and expect the same disk that was formerly attached non-statically to slot 5 now to pop up in slot 4
         # through implicit BDF allocation.
         hotplug(
@@ -740,7 +817,9 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             "virsh attach-disk --domain testvm --target vdb --source /var/lib/libvirt/storage-pools/nfs-share/vdb.img",
         )
         self.assertEqual(
-            pci_devices_by_bdf(controllerVM).get("00:04.0"), VIRTIO_BLOCK_DEVICE
+            pci_devices_by_bdf(controllerVM).get("00:04.0"),
+            VIRTIO_BLOCK_DEVICE,
+            "device type at BDF 00:04.0 should match",
         )
 
         # Check that BDFs stay the same after migration
@@ -750,7 +829,11 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         )
         wait_for_ssh(computeVM)
         devices_after_livemig = pci_devices_by_bdf(computeVM)
-        self.assertEqual(devices_before_livemig, devices_after_livemig)
+        self.assertEqual(
+            devices_before_livemig,
+            devices_after_livemig,
+            "devices before and after migration should match",
+        )
 
     def test_bdf_explicit_assignment(self):
         """
@@ -779,13 +862,37 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         )
 
         devices = pci_devices_by_bdf(controllerVM)
-        self.assertEqual(devices["00:01.0"], VIRTIO_BLOCK_DEVICE)
-        self.assertEqual(devices["00:02.0"], VIRTIO_NETWORK_DEVICE)
-        self.assertIsNone(devices.get("00:03.0"))
-        self.assertEqual(devices["00:04.0"], VIRTIO_NETWORK_DEVICE)
-        self.assertEqual(devices["00:05.0"], VIRTIO_ENTROPY_SOURCE)
-        self.assertIsNone(devices.get("00:06.0"))
-        self.assertEqual(devices["00:17.0"], VIRTIO_BLOCK_DEVICE)
+        self.assertEqual(
+            devices["00:01.0"],
+            VIRTIO_BLOCK_DEVICE,
+            "device type at BDF 00:01.0 should match",
+        )
+        self.assertEqual(
+            devices["00:02.0"],
+            VIRTIO_NETWORK_DEVICE,
+            "device type at BDF 00:02.0 should match",
+        )
+        self.assertIsNone(
+            devices.get("00:03.0"), "no device should exist at BDF 00:03.0"
+        )
+        self.assertEqual(
+            devices["00:04.0"],
+            VIRTIO_NETWORK_DEVICE,
+            "device type at BDF 00:04.0 should match",
+        )
+        self.assertEqual(
+            devices["00:05.0"],
+            VIRTIO_ENTROPY_SOURCE,
+            "device type at BDF 00:05.0 should match",
+        )
+        self.assertIsNone(
+            devices.get("00:06.0"), "no device should exist at BDF 00:06.0"
+        )
+        self.assertEqual(
+            devices["00:17.0"],
+            VIRTIO_BLOCK_DEVICE,
+            "device type at BDF 00:17.0 should match",
+        )
 
         # Check that BDF is freed and can be reallocated when de-/attaching a (entirely different) device
         hotplug(
@@ -793,14 +900,24 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             "virsh detach-device testvm /etc/new_interface_explicit_bdf.xml",
         )
         hotplug(controllerVM, "virsh detach-disk --domain testvm --target vdb")
-        self.assertIsNone(pci_devices_by_bdf(controllerVM).get("00:04.0"))
-        self.assertIsNone(pci_devices_by_bdf(controllerVM).get("00:17.0"))
+        self.assertIsNone(
+            pci_devices_by_bdf(controllerVM).get("00:04.0"),
+            "no device should exist at BDF 00:04.0",
+        )
+        self.assertIsNone(
+            pci_devices_by_bdf(controllerVM).get("00:17.0"),
+            "no device should exist at BDF 00:17.0",
+        )
         hotplug(
             controllerVM,
             "virsh attach-disk --domain testvm --target vdb --source /var/lib/libvirt/storage-pools/nfs-share/cirros.img --address pci:0.0.04.0",
         )
         devices_before_livemig = pci_devices_by_bdf(controllerVM)
-        self.assertEqual(devices_before_livemig["00:04.0"], VIRTIO_BLOCK_DEVICE)
+        self.assertEqual(
+            devices_before_livemig["00:04.0"],
+            VIRTIO_BLOCK_DEVICE,
+            "device type at BDF 00:04.0 should match",
+        )
 
         # Adding to the same bdf twice fails
         hotplug_fail(
@@ -814,7 +931,11 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         )
         wait_for_ssh(computeVM)
         devices_after_livemig = pci_devices_by_bdf(computeVM)
-        self.assertEqual(devices_before_livemig, devices_after_livemig)
+        self.assertEqual(
+            devices_before_livemig,
+            devices_after_livemig,
+            "devices before and after migration should match",
+        )
 
     def test_live_migration_to_self_is_rejected(self):
         """
@@ -883,7 +1004,7 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
 
             # Check VM is still responsive
             out = ssh(controllerVM, "echo -n Hello Cyberus!")
-            self.assertEqual(out, "Hello Cyberus!")
+            self.assertEqual(out, "Hello Cyberus!", "VM should still be responsive")
 
             computeVM.succeed("kill -9 $(pidof cloud-hypervisor)")
             # Wait until `virsh migrate` returns (finished its cleanup)
@@ -893,7 +1014,7 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
 
             # Check VM is still responsive
             out = ssh(controllerVM, "echo -n Hello Cyberus!")
-            self.assertEqual(out, "Hello Cyberus!")
+            self.assertEqual(out, "Hello Cyberus!", "VM should still be responsive")
 
         # Ensure migration can now continue quickly
         ssh(controllerVM, "pkill -9 screen")
@@ -921,7 +1042,11 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
         out = controllerVM.succeed("virsh domjobinfo --rawstats testvm")
 
         # No actual stats when no migration is running
-        self.assertNotIn("memory_total:", out)
+        self.assertNotIn(
+            "memory_total:",
+            out,
+            "should not have domjobinfo metric when no migration is outgoing",
+        )
 
         # Stress the CH VM in order to make the migration take longer
         ssh(controllerVM, "screen -dmS stress stress -m 2 --vm-bytes 1000M")
@@ -942,13 +1067,17 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             "memory_total:",
             "time_elapsed",
         ]:
-            self.assertIn(entry, out)
+            self.assertIn(entry, out, "should have domjobinfo metric")
 
         # Receiving side does not offer statistics about the incoming migration
         out = computeVM.succeed("virsh domjobinfo --rawstats testvm")
 
         # No actual stats when no migration is running
-        self.assertNotIn("memory_total:", out)
+        self.assertNotIn(
+            "memory_total:",
+            out,
+            "should not have domjobinfo metric when no migration is outgoing",
+        )
 
         try:
             # Turn off the stress process to let the migration finish faster


### PR DESCRIPTION
A `self.assertEqual()` may result in

```
Traceback (most recent call last):
  File "<string>", line 566, in test_live_migration_tls
AssertionError: 10 != 5
```

Not very helpful. With this change, we add more context to all such messages, which will be printed as:

```
Traceback (most recent call last):
  File "<string>", line 566, in test_live_migration_tls
AssertionError: 10 != 5 : number of server_hellos should match
```

Much better! At a first glance, one know what component or property is affected.

