### PR TITLE
tests: consolidate Meson sanitizer flags

### DIFF
--- a/tests/common.nix
+++ b/tests/common.nix
@@ -388,6 +388,7 @@ in
   systemd.services.virtchd = {
     environment.ASAN_OPTIONS = "detect_leaks=1:fast_unwind_on_malloc=0:halt_on_error=1:symbolize=1";
     environment.LSAN_OPTIONS = "report_objects=1";
+    environment.UBSAN_OPTIONS = "halt_on_error=1:print_stacktrace=1";
   };
 
   nixpkgs.overlays = [


### PR DESCRIPTION
This PR fixes how Mesons sanitizers are configured in tests/common.nix.
- Combine multiple -Db_sanitize Meson flags into a single flag.
- ~Extend the sanitizer list with: thread (TSan) and memory (MSan)~  Address (ASan), Thread (TSan) and Memory (MSan) are mutually exclusive, thus would require separate builds. I removed this addition to keep the build simple for now.