### PR TITLE
qemu: 6 instead of 4 cores

### DIFF
--- a/tests/common.nix
+++ b/tests/common.nix
@@ -108,6 +108,7 @@ let
         ${
           if numa then
             ''
+              <!-- Keep in sync with QEMU VM vCPUs. -->
               <vcpu placement='static'>4</vcpu>
               <cputune>
                 <vcpupin vcpu='0' cpuset='0-1'/>
@@ -154,6 +155,7 @@ let
             ''
           else
             ''
+              <!-- Keep in sync with QEMU VM vCPUs. -->
               <vcpu placement='static'>2</vcpu>
               ${
                 if hugepages then
@@ -399,6 +401,20 @@ in
     enable = true;
     sshProxy = false;
     package = libvirtCh;
+  };
+
+  virtualisation = {
+    # We allocate up to four cores to each Cloud Hypervisor VM. To guarantee
+    # forward progress of the QEMU host VM and the test script - even when the
+    # Cloud Hypervisor VM is under 100% load - we provision two additional vCPUs
+    # to each QEMU VM.
+    #
+    # The additional overhead is negligible to the systems running the test, as
+    # the QEMU threads will be mostly idling.
+    cores = 6;
+    memorySize = 4096;
+    interfaces.eth1.vlan = 1;
+    diskSize = 8192;
   };
 
   systemd.services.virtstoraged.path = [ pkgs.mount ];

--- a/tests/numa-domain-xml.nix
+++ b/tests/numa-domain-xml.nix
@@ -21,6 +21,7 @@ let
         <uuid>4eb6319a-4302-4407-9a56-802fc7e6a422</uuid>
         <memory unit='MiB'>512</memory>
         <currentMemory unit='MiB'>512</currentMemory>
+        <!-- Keep in sync with QEMU VM vCPUs. -->
         <vcpu placement='static'>2</vcpu>
         <cputune>
         ${


### PR DESCRIPTION
We allow up to 4 cores per Cloud Hypervisor VM. If all of them are under 100% load, it might happen that the test script (running in QEMU) needs longer time to be able to submit the next action.

With this, we give the QEMU VM more computational power and prevent potential flakiness.

The changes should not be visible to guests.

# Steps to Undraft
- [ ] Discuss with team
- [ ] Green pipeline