### PR TITLE
nix: silence polkit messages

### DIFF
--- a/tests/common.nix
+++ b/tests/common.nix
@@ -500,6 +500,10 @@ in
       PermitEmptyPasswords = "yes";
     };
   };
+  systemd.services.polkit.serviceConfig.LogFilterPatterns = [
+    "~Registered Authentication Agent"
+    "~Unregistered Authentication Agent"
+  ];
 
   # The following works around the infamous
   # `Bad owner or permissions on /nix/store/ymmaa926pv3f3wlgpw9y1aygdvqi1m7j-systemd-257.6/lib/systemd/ssh_config.d/20-systemd-ssh-proxy.conf`


### PR DESCRIPTION
Executing commands in one of the VMs makes polkitd emit messages (`polkitd[855]: Registered Authentication Agent...`) that spam the log in some tests. The messages are not helpful, they are just annoying. Thus this commit silences them.

This was originally part of https://github.com/cyberus-technology/libvirt-tests/pull/167, but I was asked to create an extra PR for it to get it merged faster.