### PR TITLE
flake: add example for gitlab dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
     # A local path can be used for developing or testing local changes. Make
     # sure the submodules in a local libvirt checkout are populated.
     # libvirt.url = "git+file:<path/to/libvirt>?submodules=1";
+    # libvirt.url = "git+ssh://git@gitlab.cyberus-technology.de/cyberus/cloud/libvirt.git?ref=gardenlinux&submodules=1";
     libvirt.url = "git+https://github.com/cyberus-technology/libvirt?ref=gardenlinux&submodules=1";
     libvirt.inputs.cloud-hypervisor.follows = "cloud-hypervisor";
     # Break the chain of cyclic dependencies:


### PR DESCRIPTION
This is helpful to work on intermediate states in our forks. It is far from trivial to get this URL "out of nowhere", so let's keep it as template.
