### PR TITLE
tests: Extend CPU features used in CPU profile live-migration test

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -116,7 +116,7 @@ let
 
               [
                 "-cpu"
-                "Cascadelake-Server-v5,+vmx"
+                "Cascadelake-Server-v5,+vmx,+stibp,+md-clear,+flush-l1d,+gds-no,+vmx-tsc-scaling"
               ];
           }
         )
@@ -129,7 +129,7 @@ let
 
               [
                 "-cpu"
-                "Icelake-Server-v7,+vmx"
+                "Icelake-Server-v7,+vmx,+stibp,+md-clear,+flush-l1d,+gds-no,+vmx-tsc-scaling"
               ];
           }
         )


### PR DESCRIPTION
Once https://github.com/cyberus-technology/cloud-hypervisor/pull/103 is merged then the existing `test_live_migration_with_cpu_profiles` test will no longer pass due to the updated CPUID and MSR requirements
of the Skylake CPU profile.

This PR adds the extra necessary CPU features to the QEMU command line in order to make CHV boot with the Skylake CPU profile and thus keeps the aforementioned test in a working state.

I have verified that this does indeed work as intended by running the test on a Granite Rapids server.