### PR TITLE
Check that raw disks are not configured as sparse

### DIFF
--- a/tests/testsuite_default.py
+++ b/tests/testsuite_default.py
@@ -1315,6 +1315,14 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             f"virsh attach-disk testvm {image} vdb --targetbus virtio --sourcetype file --subdriver raw",
         )
         ssh(controllerVM, "dd if=/dev/random of=/dev/vdb bs=512 count=1 oflag=direct")
+
+        # By default, Cloud Hypervisor sets sparse=on for raw images which we set to false in our libvirt
+        # driver to prevent overcommitting of storage backends.
+        controllerVM.succeed(
+            "ch-remote --api-socket /run/libvirt/ch/testvm-socket info \
+                              | jq -e '.config.disks[1].sparse == false' > /dev/null"
+        )
+
         hotplug(controllerVM, "virsh detach-disk testvm vdb")
 
         controllerVM.succeed(f"rm {image}")


### PR DESCRIPTION
CHV uses sparse=true as default. If the user configures a raw disk, we don't want that to be enabled. The reason is that the user expects that a raw file consumes the disk space that is actually allocated. Otherwise, one may run out of disk space during runtime.

libvirt MR: https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/merge_requests/140