### PR TITLE
Increase log level of nixos guest

### DIFF
--- a/images/nixos-image.nix
+++ b/images/nixos-image.nix
@@ -35,6 +35,10 @@ nixpkgs.lib.nixosSystem {
         ];
         boot.loader.timeout = lib.mkForce 0;
 
+        # Set the log level to `KERN_DEBUG`. This increases the log output and
+        # thus helps debugging.
+        boot.consoleLogLevel = lib.mkForce 7;
+
         documentation = {
           enable = false;
           doc.enable = false;


### PR DESCRIPTION
Increase the kernel log level to the maximum. With this we would have found the root-cause for https://github.com/cobaltcore-dev/cobaltcore/issues/418 within hours.