### PR TITLE
Add regression test for save/ restore during boot

### DIFF
--- a/test_helper/test_helper/__init__.py
+++ b/test_helper/test_helper/__init__.py
@@ -1,4 +1,5 @@
 from .test_helper import (
+    assert_domain_running,
     CommandGuard,
     LibvirtTestsBase,
     VIRTIO_BLOCK_DEVICE,
@@ -33,6 +34,7 @@ from .test_helper import (
 )
 
 __all__ = [
+    "assert_domain_running",
     "CommandGuard",
     "LibvirtTestsBase",
     "VIRTIO_BLOCK_DEVICE",

--- a/test_helper/test_helper/test_helper.py
+++ b/test_helper/test_helper/test_helper.py
@@ -150,6 +150,12 @@ def initialComputeVMSetup(computeVM: Machine) -> None:
     computeVM.succeed("virsh pool-start nfs-share")
 
 
+def assert_domain_running(machine: Machine) -> None:
+    state = machine.succeed("virsh domstate testvm")
+    if "running" not in state:
+        raise AssertionError(f"expected 'testvm' to be running, got {state!r}")
+
+
 def setupTestControllerVM(controllerVM: Machine, test: unittest.TestCase) -> None:
     if controllerVM.name != "controllerVM":
         raise RuntimeError(

--- a/tests/testsuite_default.py
+++ b/tests/testsuite_default.py
@@ -9,6 +9,7 @@ import unittest
 # additional IDE configuration.
 try:
     from ..test_helper.test_helper import (  # type: ignore
+        assert_domain_running,
         LibvirtTestsBase,
         hotplug,
         hotplug_fail,
@@ -27,6 +28,7 @@ try:
     )
 except Exception:
     from test_helper import (
+        assert_domain_running,
         LibvirtTestsBase,
         hotplug,
         hotplug_fail,
@@ -353,6 +355,23 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             # interfaces.
             retries=350,
         )
+
+    def test_save_restore_during_boot(self):
+        """
+        Test save and restore while the VM is in early boot.
+        """
+        save_file = "/tmp/testvm.save"
+
+        controllerVM.succeed("virsh define /etc/domain-chv-serial-file.xml")
+        controllerVM.succeed("virsh start testvm")
+
+        time.sleep(1)
+
+        # Trigger save while the guest is still in early boot.
+        controllerVM.succeed(f"virsh save testvm {save_file}")
+        controllerVM.succeed(f"virsh restore {save_file}")
+        assert_domain_running(controllerVM)
+        wait_for_ssh(controllerVM)
 
     def test_serial_file_output(self):
         """
@@ -1359,6 +1378,7 @@ def suite():
         LibvirtTests.test_raw_image_is_properly_attached,
         LibvirtTests.test_reboot_externallytriggered,
         LibvirtTests.test_reboot_guestinduced,
+        LibvirtTests.test_save_restore_during_boot,
         LibvirtTests.test_serial_file_output,
         LibvirtTests.test_serial_tcp,
         LibvirtTests.test_shutdown,

--- a/tests/testsuite_migration.py
+++ b/tests/testsuite_migration.py
@@ -9,6 +9,7 @@ import unittest
 # additional IDE configuration.
 try:
     from ..test_helper.test_helper import (  # type: ignore
+        assert_domain_running,
         CommandGuard,
         LibvirtTestsBase,
         VIRTIO_BLOCK_DEVICE,
@@ -31,6 +32,7 @@ try:
     )
 except Exception:
     from test_helper import (
+        assert_domain_running,
         CommandGuard,
         LibvirtTestsBase,
         VIRTIO_BLOCK_DEVICE,
@@ -69,10 +71,6 @@ if "start_all" not in globals():
 
 def guest_boot_id(machine: Machine) -> str:
     return ssh(machine, "cat /proc/sys/kernel/random/boot_id").strip()
-
-
-def assert_domain_running(machine: Machine) -> None:
-    machine.succeed("virsh domstate testvm | grep -q running")
 
 
 def domain_is_running(machine: Machine) -> bool:


### PR DESCRIPTION
This PR adds a regression test for [issue](https://github.com/cobaltcore-dev/cobaltcore/issues/418) and its [fix](https://github.com/cyberus-technology/cloud-hypervisor/pull/118).

It also moves `assert_domain_running` into the shared test helper, as it is shared now.
In addition, test failures now export `/tmp/vm_serial.log` together with the existing chv and libvirt logs to make debugging easier.

 [pipeline](https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/pipelines/202621)