### PR TITLE
Add option to build OVMF in debug mode

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,11 +80,24 @@
             );
           })
         ];
+        ovmf-debug = pkgs.OVMF.override { debug = true; };
 
-        chv-ovmf = pkgs.OVMF-cloud-hypervisor.overrideAttrs (_old: {
+        chv-ovmf-release = pkgs.OVMF-cloud-hypervisor.overrideAttrs (_old: {
           version = "cbs";
           src = edk2-src;
         });
+
+        chv-ovmf-debug =
+          (pkgs.OVMF-cloud-hypervisor.override {
+            OVMF = ovmf-debug;
+          }).overrideAttrs
+            (_old: {
+              version = "cbs-debug";
+              src = edk2-src;
+              patches = [ ]; # add custom EDK2 patches here
+            });
+
+        chv-ovmf = chv-ovmf-release;
 
         nixos-image' =
           (pkgs.callPackage ./images/nixos-image.nix { inherit nixpkgs; }).config.system.build.isoImage;


### PR DESCRIPTION
Whenever we need to build edk2 in debug mode, we need to change flake.nix to even have the capability to do so. Add the necessary bits and pieces here so we can start debugging right away.