### PR TITLE
nix: use previous version of `libvirt` in version migration tests

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,6 +48,31 @@
         "type": "github"
       }
     },
+    "cloud-hypervisor-prev_2": {
+      "inputs": {
+        "crane": "crane_3",
+        "dried-nix-flakes": "dried-nix-flakes_4",
+        "nixpkgs": [
+          "libvirt",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_3"
+      },
+      "locked": {
+        "lastModified": 1774955977,
+        "narHash": "sha256-O41HNDYh/HkmS4OutJi0euw+0HnaXXnSo5d1NBxLTeU=",
+        "owner": "cyberus-technology",
+        "repo": "cloud-hypervisor",
+        "rev": "48607f37f78f479b65780eba5801c943210fc38f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cyberus-technology",
+        "ref": "gardenlinux-release-26-03-31",
+        "repo": "cloud-hypervisor",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
         "lastModified": 1772560058,
@@ -65,6 +90,22 @@
       }
     },
     "crane_2": {
+      "locked": {
+        "lastModified": 1772560058,
+        "narHash": "sha256-NuVKdMBJldwUXgghYpzIWJdfeB7ccsu1CC7B+NfSoZ8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "db590d9286ed5ce22017541e36132eab4e8b3045",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "master",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_3": {
       "locked": {
         "lastModified": 1772560058,
         "narHash": "sha256-NuVKdMBJldwUXgghYpzIWJdfeB7ccsu1CC7B+NfSoZ8=",
@@ -140,6 +181,36 @@
         "type": "github"
       }
     },
+    "dried-nix-flakes_5": {
+      "locked": {
+        "lastModified": 1756139350,
+        "narHash": "sha256-pObQv94NclXVXjJV8sTiKwFes4fGEWpkNzDsXw5DqnY=",
+        "owner": "cyberus-technology",
+        "repo": "dried-nix-flakes",
+        "rev": "1b2ba62710c6c1d9eba0e8e3adc029cc2e9291a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cyberus-technology",
+        "repo": "dried-nix-flakes",
+        "type": "github"
+      }
+    },
+    "dried-nix-flakes_6": {
+      "locked": {
+        "lastModified": 1756139350,
+        "narHash": "sha256-pObQv94NclXVXjJV8sTiKwFes4fGEWpkNzDsXw5DqnY=",
+        "owner": "cyberus-technology",
+        "repo": "dried-nix-flakes",
+        "rev": "1b2ba62710c6c1d9eba0e8e3adc029cc2e9291a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cyberus-technology",
+        "repo": "dried-nix-flakes",
+        "type": "github"
+      }
+    },
     "edk2-src": {
       "flake": false,
       "locked": {
@@ -178,9 +249,69 @@
         "url": "https://github.com/cyberus-technology/edk2"
       }
     },
+    "edk2-src_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772632652,
+        "narHash": "sha256-cuU4f9U4zAj03cDhirjru4XSVM5WjpW59wEiiR3Qa/Q=",
+        "ref": "gardenlinux",
+        "rev": "1d892a18e3c6b0e4ead9ab26c9a4f648bbf31476",
+        "revCount": 35525,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/cyberus-technology/edk2"
+      },
+      "original": {
+        "ref": "gardenlinux",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/cyberus-technology/edk2"
+      }
+    },
+    "edk2-src_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772632652,
+        "narHash": "sha256-cuU4f9U4zAj03cDhirjru4XSVM5WjpW59wEiiR3Qa/Q=",
+        "ref": "gardenlinux",
+        "rev": "1d892a18e3c6b0e4ead9ab26c9a4f648bbf31476",
+        "revCount": 35525,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/cyberus-technology/edk2"
+      },
+      "original": {
+        "ref": "gardenlinux",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/cyberus-technology/edk2"
+      }
+    },
     "fcntl-tool": {
       "inputs": {
         "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775080936,
+        "narHash": "sha256-Fq/d//tIRG7XPirsUX1fmHucorkx7fS3Uhk1RNTJxjI=",
+        "owner": "phip1611",
+        "repo": "fcntl-tool",
+        "rev": "55d6200678996060e58d152598d2583a2ef889a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phip1611",
+        "repo": "fcntl-tool",
+        "type": "github"
+      }
+    },
+    "fcntl-tool_2": {
+      "inputs": {
+        "nixpkgs": [
+          "libvirt",
+          "libvirt-tests",
           "nixpkgs"
         ]
       },
@@ -198,10 +329,10 @@
         "type": "github"
       }
     },
-    "fcntl-tool_2": {
+    "fcntl-tool_3": {
       "inputs": {
         "nixpkgs": [
-          "libvirt",
+          "libvirt-prev",
           "libvirt-tests",
           "nixpkgs"
         ]
@@ -236,11 +367,44 @@
         "url": "https://gitlab.com/keycodemap/keycodemapdb.git"
       }
     },
+    "keycodemapdb_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752156361,
+        "narHash": "sha256-gfrQPAwgShtgkDWZOkivDO1Aj7UUdaGTitirGy+RA70=",
+        "ref": "refs/heads/master",
+        "rev": "54788039c0b3486a8883090d6736c2500177af29",
+        "revCount": 89,
+        "type": "git",
+        "url": "https://gitlab.com/keycodemap/keycodemapdb.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://gitlab.com/keycodemap/keycodemapdb.git"
+      }
+    },
+    "keycodemapdb_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752156361,
+        "narHash": "sha256-gfrQPAwgShtgkDWZOkivDO1Aj7UUdaGTitirGy+RA70=",
+        "ref": "refs/heads/master",
+        "rev": "54788039c0b3486a8883090d6736c2500177af29",
+        "revCount": 89,
+        "type": "git",
+        "url": "https://gitlab.com/keycodemap/keycodemapdb.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://gitlab.com/keycodemap/keycodemapdb.git"
+      }
+    },
     "libvirt": {
       "inputs": {
         "cloud-hypervisor": [
           "cloud-hypervisor"
         ],
+        "cloud-hypervisor-prev": "cloud-hypervisor-prev_2",
         "edk2-src": "edk2-src_2",
         "keycodemapdb": "keycodemapdb",
         "libvirt-tests": "libvirt-tests",
@@ -249,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775017835,
-        "narHash": "sha256-/5EV3JaAsnjH6YKEX1aHzb7AXgT++mUMbwPydI2yLy4=",
+        "lastModified": 1775651073,
+        "narHash": "sha256-GAIj4usbQLMgdt1hoJm0ZvhCXPAef/YK2Z0QgM5rjdo=",
         "ref": "gardenlinux",
-        "rev": "52bc32de967ca6ef020d1ad14c1a9afd598ba81d",
-        "revCount": 54148,
+        "rev": "35bbe888c2ceb1f5a07e4ab82185b1f5f504728d",
+        "revCount": 54150,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/cyberus-technology/libvirt"
@@ -265,13 +429,44 @@
         "url": "https://github.com/cyberus-technology/libvirt"
       }
     },
+    "libvirt-prev": {
+      "inputs": {
+        "cloud-hypervisor": [
+          "cloud-hypervisor-prev"
+        ],
+        "edk2-src": "edk2-src_3",
+        "keycodemapdb": "keycodemapdb_2",
+        "libvirt-tests": "libvirt-tests_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1774940944,
+        "narHash": "sha256-z6+PU8+lTBE2HG4bsb15EY4AmywB+28j6dr6X7Ak36A=",
+        "ref": "refs/tags/gardenlinux-release-26-03-31",
+        "rev": "db2f30fce426ff3f61de01874b2ee8a9aca43a7b",
+        "revCount": 54144,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/cyberus-technology/libvirt"
+      },
+      "original": {
+        "ref": "refs/tags/gardenlinux-release-26-03-31",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/cyberus-technology/libvirt"
+      }
+    },
     "libvirt-tests": {
       "inputs": {
         "cloud-hypervisor": [
           "libvirt",
           "cloud-hypervisor"
         ],
-        "dried-nix-flakes": "dried-nix-flakes_4",
+        "cloud-hypervisor-prev": [
+          "libvirt",
+          "cloud-hypervisor-prev"
+        ],
+        "dried-nix-flakes": "dried-nix-flakes_5",
         "edk2-src": [
           "libvirt",
           "edk2-src"
@@ -286,11 +481,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774944476,
-        "narHash": "sha256-8lrfFWHAhUIhhdQFDKtVTGhsJCn96w5hLD5ClxViLsE=",
+        "lastModified": 1775643093,
+        "narHash": "sha256-mfTW7VyNyRGSz7Do29rkeOWrO1XfdJxqfn3HGHzra98=",
         "owner": "cyberus-technology",
         "repo": "libvirt-tests",
-        "rev": "cae7c66098c1602835ce90a9a88ea1843354ad0d",
+        "rev": "6b477b0586a963e5ae497ea41bf36543969ad9df",
         "type": "github"
       },
       "original": {
@@ -300,13 +495,98 @@
         "type": "github"
       }
     },
+    "libvirt-tests_2": {
+      "inputs": {
+        "cloud-hypervisor": [
+          "libvirt-prev",
+          "cloud-hypervisor"
+        ],
+        "dried-nix-flakes": "dried-nix-flakes_6",
+        "edk2-src": [
+          "libvirt-prev",
+          "edk2-src"
+        ],
+        "fcntl-tool": "fcntl-tool_3",
+        "libvirt": "libvirt_2",
+        "nixpkgs": [
+          "libvirt-prev",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774606075,
+        "narHash": "sha256-j/WovhxpXpxejvnn7NfGtRlPWpoYctKiunA3BqUXVks=",
+        "owner": "cyberus-technology",
+        "repo": "libvirt-tests",
+        "rev": "19e1e2e964ff52e9e9cebfc075f4b57cb7d1570f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cyberus-technology",
+        "ref": "main",
+        "repo": "libvirt-tests",
+        "type": "github"
+      }
+    },
+    "libvirt_2": {
+      "inputs": {
+        "cloud-hypervisor": [
+          "libvirt-prev",
+          "libvirt-tests",
+          "cloud-hypervisor"
+        ],
+        "edk2-src": "edk2-src_4",
+        "keycodemapdb": "keycodemapdb_3",
+        "libvirt-tests": [
+          "libvirt-prev",
+          "libvirt-tests"
+        ],
+        "nixpkgs": [
+          "libvirt-prev",
+          "libvirt-tests",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772714211,
+        "narHash": "sha256-VoeFKlozEcwWowkdk4nhxb7DuWjPGINpvpETtiATq8c=",
+        "ref": "gardenlinux",
+        "rev": "1d5e5cf5faf9cd2b60af400ddc76a8377c7f7f5a",
+        "revCount": 54117,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/cyberus-technology/libvirt"
+      },
+      "original": {
+        "ref": "gardenlinux",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/cyberus-technology/libvirt"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774799055,
-        "narHash": "sha256-Tsq9BCz0q47ej1uFF39m4tuhcwru/ls6vCCJzutEpaw=",
+        "lastModified": 1772822230,
+        "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "107cba9eb4a8d8c9f8e9e61266d78d340867913a",
+        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1775595990,
+        "narHash": "sha256-OEf7YqhF9IjJFYZJyuhAypgU+VsRB5lD4DuiMws5Ltc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4e92bbcdb030f3b4782be4751dc08e6b6cb6ccf2",
         "type": "github"
       },
       "original": {
@@ -324,7 +604,8 @@
         "edk2-src": "edk2-src",
         "fcntl-tool": "fcntl-tool",
         "libvirt": "libvirt",
-        "nixpkgs": "nixpkgs"
+        "libvirt-prev": "libvirt-prev",
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "rust-overlay": {
@@ -351,6 +632,28 @@
     "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
+          "cloud-hypervisor-prev",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772679930,
+        "narHash": "sha256-FxYmdacqrdDVeE9QqZKTIpNLjv2B8GSKssgwlZuTR98=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "9b741db17141331fdb26270a1b66b81be8be9edd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_3": {
+      "inputs": {
+        "nixpkgs": [
+          "libvirt",
           "cloud-hypervisor-prev",
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,10 @@
     cloud-hypervisor-prev.url = "github:cyberus-technology/cloud-hypervisor?ref=gardenlinux-release-26-03-31";
     cloud-hypervisor-prev.inputs.nixpkgs.follows = "nixpkgs";
 
+    # Previous release of libvirt to match cloud-hypervisor's previous version.
+    libvirt-prev.url = "git+https://github.com/cyberus-technology/libvirt?ref=refs/tags/gardenlinux-release-26-03-31&submodules=1";
+    libvirt-prev.inputs.cloud-hypervisor.follows = "cloud-hypervisor-prev";
+
     edk2-src.url = "git+https://github.com/cyberus-technology/edk2?ref=gardenlinux&submodules=1";
     edk2-src.flake = false;
 
@@ -73,6 +77,7 @@
         edk2-src,
         fcntl-tool,
         libvirt,
+        libvirt-prev,
         nixpkgs,
         ...
       }:
@@ -83,6 +88,7 @@
             cloud-hypervisor = toDebugOptimizedChv cloud-hypervisor.packages.default;
             cloud-hypervisor-prev = toDebugOptimizedChv cloud-hypervisor-prev.packages.default;
             libvirt = libvirt.packages.libvirt-debugoptimized;
+            libvirt-prev = libvirt-prev.packages.libvirt-debugoptimized;
             python3Packages = prev.python3Packages.overrideScope (
               _: _: {
                 inherit test-helper;
@@ -235,7 +241,12 @@
         # We export all artifacts that we also have in the tests.
         packages = {
           # Export of the overlay'ed package
-          inherit (pkgs) cloud-hypervisor cloud-hypervisor-prev libvirt;
+          inherit (pkgs)
+            cloud-hypervisor
+            cloud-hypervisor-prev
+            libvirt
+            libvirt-prev
+            ;
           inherit nixos-image;
           chv-ovmf = pkgs.runCommand "OVMF-CLOUHDHV.fd" { } ''
             cp ${chv-ovmf.fd}/FV/CLOUDHV.fd $out

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,8 @@
 
     # A local path can be used for developing or testing local changes. Make
     # sure the submodules in a local libvirt checkout are populated.
+    # Using the shorthand notation of "github:user/repo..." may lead to build errors
+    # like "source-with-submodules> cp: cannot create regular file '[...]': Permission denied".
     # libvirt.url = "git+file:<path/to/libvirt>?submodules=1";
     # libvirt.url = "git+ssh://git@gitlab.cyberus-technology.de/cyberus/cloud/libvirt.git?ref=gardenlinux&submodules=1";
     libvirt.url = "git+https://github.com/cyberus-technology/libvirt?ref=gardenlinux&submodules=1";

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,7 @@
             fcntl-tool = fcntl-tool.packages.default;
             cloud-hypervisor = toDebugOptimizedChv cloud-hypervisor.packages.default;
             cloud-hypervisor-prev = toDebugOptimizedChv cloud-hypervisor-prev.packages.default;
+            libvirt = libvirt.packages.libvirt-debugoptimized;
             python3Packages = prev.python3Packages.overrideScope (
               _: _: {
                 inherit test-helper;
@@ -234,7 +235,7 @@
         # We export all artifacts that we also have in the tests.
         packages = {
           # Export of the overlay'ed package
-          inherit (pkgs) cloud-hypervisor cloud-hypervisor-prev;
+          inherit (pkgs) cloud-hypervisor cloud-hypervisor-prev libvirt;
           inherit nixos-image;
           chv-ovmf = pkgs.runCommand "OVMF-CLOUHDHV.fd" { } ''
             cp ${chv-ovmf.fd}/FV/CLOUDHV.fd $out
@@ -246,7 +247,6 @@
             nixos-image
             chv-ovmf
             ;
-          libvirt = libvirt.packages.libvirt-debugoptimized;
         };
       }
     );

--- a/tests/common.nix
+++ b/tests/common.nix
@@ -3,7 +3,6 @@
 # The module defines the common parts of the host VMs.
 
 {
-  libvirt,
   nixos-image,
   chv-ovmf,
 }:
@@ -381,57 +380,6 @@ let
       </ip>
     </network>
   '';
-
-  # libvirt with cloud hypervisor patches, debugoptimized build, sanitizer
-  # support, and reduced to what we need for quicker compile times.
-  libvirtCh = libvirt.overrideAttrs (old: {
-    # name for the build logs
-    name = "libvirt-chv-tests";
-    # Reduce files needed to compile. We cut the build-time in half.
-    mesonFlags = old.mesonFlags ++ [
-      # Disabling tests: 1500 -> 1200
-      "-Dtests=disabled"
-      "-Dexpensive_tests=disabled"
-      # Disabling docs: 1200 -> 800
-      "-Ddocs=disabled"
-      # Disabling unneeded backends: 800 -> 685
-      "-Ddriver_ch=enabled"
-      "-Ddriver_qemu=disabled"
-      "-Ddriver_bhyve=disabled"
-      "-Ddriver_esx=disabled"
-      "-Ddriver_hyperv=disabled"
-      "-Ddriver_libxl=disabled"
-      "-Ddriver_lxc=disabled"
-      "-Ddriver_openvz=disabled"
-      "-Ddriver_secrets=disabled"
-      "-Ddriver_vbox=disabled"
-      "-Ddriver_vmware=disabled"
-      "-Ddriver_vz=disabled"
-      "-Dstorage_dir=disabled"
-      "-Dstorage_disk=disabled"
-      "-Dstorage_fs=enabled" # for netfs
-      "-Dstorage_gluster=disabled"
-      "-Dstorage_iscsi=disabled"
-      "-Dstorage_iscsi_direct=disabled"
-      "-Dstorage_lvm=disabled"
-      "-Dstorage_mpath=disabled"
-      "-Dstorage_rbd=disabled"
-      "-Dstorage_scsi=disabled"
-      "-Dstorage_vstorage=disabled"
-      "-Dstorage_zfs=disabled"
-      "-Dapparmor=disabled"
-      "-Dwireshark_dissector=disabled"
-      "-Dselinux=disabled"
-      "-Dsecdriver_apparmor=disabled"
-      "-Dsecdriver_selinux=disabled"
-      "-Db_sanitize=leak,address,undefined"
-      # Enabling the sanitizers has led to warnings about inlining macro
-      # generated cleanup methods of the glib which spam the build log.
-      # Ignoring and suppressing the warnings seems like the only option.
-      # "warning: inlining failed in call to 'glib_autoptr_cleanup_virNetlinkMsg': call is unlikely and code size would grow [-Winline]"
-      "-Dc_args=-Wno-inline"
-    ];
-  });
 in
 {
   # Silence the monolithic libvirtd, which otherwise starts before the virtchd
@@ -454,10 +402,61 @@ in
   };
 
   nixpkgs.overlays = [
-    (_final: _prev: {
+    (_final: prev: {
+      # libvirt with cloud hypervisor patches, debugoptimized build, sanitizer
+      # support, and reduced to what we need for quicker compile times.
       # Ensure that every access to `pkgs.libvirt` falls back to our special
       # variant.
-      libvirt = libvirtCh;
+      # `prev.libvirt` refers to the `libvirt` set in the flake.nix, not the
+      # standard `libvirt` from nixpkgs.
+      libvirt = prev.libvirt.overrideAttrs (old: {
+        # name for the build logs
+        name = "libvirt-chv-tests";
+        # Reduce files needed to compile. We cut the build-time in half.
+        mesonFlags = old.mesonFlags ++ [
+          # Disabling tests: 1500 -> 1200
+          "-Dtests=disabled"
+          "-Dexpensive_tests=disabled"
+          # Disabling docs: 1200 -> 800
+          "-Ddocs=disabled"
+          # Disabling unneeded backends: 800 -> 685
+          "-Ddriver_ch=enabled"
+          "-Ddriver_qemu=disabled"
+          "-Ddriver_bhyve=disabled"
+          "-Ddriver_esx=disabled"
+          "-Ddriver_hyperv=disabled"
+          "-Ddriver_libxl=disabled"
+          "-Ddriver_lxc=disabled"
+          "-Ddriver_openvz=disabled"
+          "-Ddriver_secrets=disabled"
+          "-Ddriver_vbox=disabled"
+          "-Ddriver_vmware=disabled"
+          "-Ddriver_vz=disabled"
+          "-Dstorage_dir=disabled"
+          "-Dstorage_disk=disabled"
+          "-Dstorage_fs=enabled" # for netfs
+          "-Dstorage_gluster=disabled"
+          "-Dstorage_iscsi=disabled"
+          "-Dstorage_iscsi_direct=disabled"
+          "-Dstorage_lvm=disabled"
+          "-Dstorage_mpath=disabled"
+          "-Dstorage_rbd=disabled"
+          "-Dstorage_scsi=disabled"
+          "-Dstorage_vstorage=disabled"
+          "-Dstorage_zfs=disabled"
+          "-Dapparmor=disabled"
+          "-Dwireshark_dissector=disabled"
+          "-Dselinux=disabled"
+          "-Dsecdriver_apparmor=disabled"
+          "-Dsecdriver_selinux=disabled"
+          "-Db_sanitize=leak,address,undefined"
+          # Enabling the sanitizers has led to warnings about inlining macro
+          # generated cleanup methods of the glib which spam the build log.
+          # Ignoring and suppressing the warnings seems like the only option.
+          # "warning: inlining failed in call to 'glib_autoptr_cleanup_virNetlinkMsg': call is unlikely and code size would grow [-Winline]"
+          "-Dc_args=-Wno-inline"
+        ];
+      });
     })
   ];
 
@@ -466,7 +465,7 @@ in
   virtualisation.libvirtd = {
     enable = true;
     sshProxy = false;
-    package = libvirtCh;
+    package = pkgs.libvirt;
   };
 
   systemd.services.virtstoraged.path = [ pkgs.mount ];

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,6 +1,5 @@
 {
   pkgs,
-  libvirt,
   nixos-image,
   chv-ovmf,
   enablePortForwarding ? true,
@@ -20,7 +19,6 @@ let
     }:
     pkgs.callPackage ./libvirt-test.nix {
       inherit
-        libvirt
         nixos-image
         chv-ovmf
         testScriptFile

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -59,6 +59,8 @@ let
               (_final: _prev: {
                 # Overwrite the default cloud-hypervisor version.
                 cloud-hypervisor = pkgs.cloud-hypervisor-prev;
+                # Overwrite the default libvirt version.
+                libvirt = pkgs.libvirt-prev;
               })
             ];
           }

--- a/tests/libvirt-test.nix
+++ b/tests/libvirt-test.nix
@@ -4,7 +4,6 @@
 
 {
   pkgs,
-  libvirt, # debug-optimized libvirt package
   nixos-image,
   chv-ovmf,
   testScriptFile,
@@ -13,7 +12,7 @@
   extraComputeConfig ? [ ],
 }:
 let
-  common = import ./common.nix { inherit libvirt nixos-image chv-ovmf; };
+  common = import ./common.nix { inherit nixos-image chv-ovmf; };
   tls =
     let
       c = pkgs.callPackage ./certificates.nix { };

--- a/tests/testsuite_live_migration.py
+++ b/tests/testsuite_live_migration.py
@@ -1497,6 +1497,17 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
             sender.succeed(migration_command)
             wait_for_ssh(receiver)
 
+    def test_live_migration_print_versions(self):
+        """
+        The test prints the versions of cloud-hypervisor and libvirt.
+        With the version information, cross-version migration tests can be validated
+        to use different versions.
+        """
+        print(controllerVM.succeed("virsh version"))
+        print(computeVM.succeed("virsh version"))
+        print(controllerVM.succeed("cloud-hypervisor --version"))
+        print(computeVM.succeed("cloud-hypervisor --version"))
+
 
 def suite():
     # Test cases involving live migration sorted in alphabetical order.
@@ -1514,6 +1525,7 @@ def suite():
         LibvirtTests.test_live_migration_network_lost,
         LibvirtTests.test_live_migration_non_peer2peer_is_not_supported,
         LibvirtTests.test_live_migration_parallel_connections,
+        LibvirtTests.test_live_migration_print_versions,
         LibvirtTests.test_live_migration_statistics,
         LibvirtTests.test_live_migration_tls,
         LibvirtTests.test_live_migration_tls_without_certificates,


### PR DESCRIPTION
Since `libvirt` and `cloud-hypervisor` are shipped as pairs, the cross-version migration test should also use the appropriate `lbivirt` version. 

Libvirt PR: https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/merge_requests/166
