### PR TITLE
flake: break cyclic dependencies to avoid inflating flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1775823235,
-        "narHash": "sha256-YmLDL1IkNBuDBBCu3kX1LMCrOrVXAyMVWb0aLxOLTJI=",
+        "lastModified": 1776175591,
+        "narHash": "sha256-s3qpPtgzmdg6oW+1gvImR+Qdv6mBvphFscPMMH2LKjU=",
         "owner": "cyberus-technology",
         "repo": "cloud-hypervisor",
-        "rev": "22ad466bf76b3e25e5f6f959ff4a0a87cf8e6aa6",
+        "rev": "06092ab3f37caf5b8418baf431b5879368761f9c",
         "type": "github"
       },
       "original": {
@@ -378,44 +378,6 @@
         "url": "https://github.com/cyberus-technology/edk2"
       }
     },
-    "edk2-src_6": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1772632652,
-        "narHash": "sha256-cuU4f9U4zAj03cDhirjru4XSVM5WjpW59wEiiR3Qa/Q=",
-        "ref": "gardenlinux",
-        "rev": "1d892a18e3c6b0e4ead9ab26c9a4f648bbf31476",
-        "revCount": 35525,
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/cyberus-technology/edk2"
-      },
-      "original": {
-        "ref": "gardenlinux",
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/cyberus-technology/edk2"
-      }
-    },
-    "edk2-src_7": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1772632652,
-        "narHash": "sha256-cuU4f9U4zAj03cDhirjru4XSVM5WjpW59wEiiR3Qa/Q=",
-        "ref": "gardenlinux",
-        "rev": "1d892a18e3c6b0e4ead9ab26c9a4f648bbf31476",
-        "revCount": 35525,
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/cyberus-technology/edk2"
-      },
-      "original": {
-        "ref": "gardenlinux",
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/cyberus-technology/edk2"
-      }
-    },
     "fcntl-tool": {
       "inputs": {
         "nixpkgs": [
@@ -567,38 +529,6 @@
         "url": "https://gitlab.com/keycodemap/keycodemapdb.git"
       }
     },
-    "keycodemapdb_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1752156361,
-        "narHash": "sha256-gfrQPAwgShtgkDWZOkivDO1Aj7UUdaGTitirGy+RA70=",
-        "ref": "refs/heads/master",
-        "rev": "54788039c0b3486a8883090d6736c2500177af29",
-        "revCount": 89,
-        "type": "git",
-        "url": "https://gitlab.com/keycodemap/keycodemapdb.git"
-      },
-      "original": {
-        "type": "git",
-        "url": "https://gitlab.com/keycodemap/keycodemapdb.git"
-      }
-    },
-    "keycodemapdb_6": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1752156361,
-        "narHash": "sha256-gfrQPAwgShtgkDWZOkivDO1Aj7UUdaGTitirGy+RA70=",
-        "ref": "refs/heads/master",
-        "rev": "54788039c0b3486a8883090d6736c2500177af29",
-        "revCount": 89,
-        "type": "git",
-        "url": "https://gitlab.com/keycodemap/keycodemapdb.git"
-      },
-      "original": {
-        "type": "git",
-        "url": "https://gitlab.com/keycodemap/keycodemapdb.git"
-      }
-    },
     "libvirt": {
       "inputs": {
         "cloud-hypervisor": [
@@ -614,11 +544,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775811910,
-        "narHash": "sha256-4/mO+FED70UzzmB7EeDlq0puLRq8Irj7+goh/Vvdzaw=",
+        "lastModified": 1776253711,
+        "narHash": "sha256-KWQePt79y0Vv5/RCAmJg5LAZh4Q9d+JTsWTqouE0KTs=",
         "ref": "gardenlinux",
-        "rev": "99a4e307672e6115113d635e55f8b73b0ab06728",
-        "revCount": 54152,
+        "rev": "aad6ff2708e5a9a762cdad789cb1753ffa060a44",
+        "revCount": 54156,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/cyberus-technology/libvirt"
@@ -661,44 +591,14 @@
     "libvirt-prev_2": {
       "inputs": {
         "cloud-hypervisor": [
-          "libvirt",
-          "libvirt-tests",
           "cloud-hypervisor-prev"
         ],
         "edk2-src": "edk2-src_5",
         "keycodemapdb": "keycodemapdb_4",
-        "libvirt-tests": [
-          "libvirt",
-          "libvirt-tests"
-        ],
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1774940944,
-        "narHash": "sha256-z6+PU8+lTBE2HG4bsb15EY4AmywB+28j6dr6X7Ak36A=",
-        "ref": "refs/tags/gardenlinux-release-26-03-31",
-        "rev": "db2f30fce426ff3f61de01874b2ee8a9aca43a7b",
-        "revCount": 54144,
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/cyberus-technology/libvirt"
-      },
-      "original": {
-        "ref": "refs/tags/gardenlinux-release-26-03-31",
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/cyberus-technology/libvirt"
-      }
-    },
-    "libvirt-prev_3": {
-      "inputs": {
-        "cloud-hypervisor": [
-          "cloud-hypervisor-prev"
-        ],
-        "edk2-src": "edk2-src_6",
-        "keycodemapdb": "keycodemapdb_5",
         "libvirt-tests": "libvirt-tests_3",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1774940944,
@@ -772,18 +672,20 @@
         "libvirt": [
           "libvirt"
         ],
-        "libvirt-prev": "libvirt-prev_2",
+        "libvirt-prev": [
+          "libvirt-prev"
+        ],
         "nixpkgs": [
           "libvirt",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775806148,
-        "narHash": "sha256-zDuaO8Vuv2FNVey8qo0hNXGCFfqX+IWTpPhHlzMbELE=",
+        "lastModified": 1776252549,
+        "narHash": "sha256-pEhD8mAimYQsB+S18uj1sxPTcbPIwaOqkERVmhugvzE=",
         "owner": "cyberus-technology",
         "repo": "libvirt-tests",
-        "rev": "561f183491c598cbebea0fa473f82b0d488387b1",
+        "rev": "0d649326227a6ca9680657193d30ef0a2657c81b",
         "type": "github"
       },
       "original": {
@@ -805,7 +707,9 @@
           "edk2-src"
         ],
         "fcntl-tool": "fcntl-tool_4",
-        "libvirt": "libvirt_3",
+        "libvirt": [
+          "libvirt-prev"
+        ],
         "nixpkgs": [
           "libvirt-prev",
           "nixpkgs"
@@ -865,81 +769,13 @@
         "url": "https://github.com/cyberus-technology/libvirt"
       }
     },
-    "libvirt_3": {
-      "inputs": {
-        "cloud-hypervisor": [
-          "libvirt-prev",
-          "libvirt-tests",
-          "cloud-hypervisor"
-        ],
-        "edk2-src": "edk2-src_7",
-        "keycodemapdb": "keycodemapdb_6",
-        "libvirt-tests": [
-          "libvirt-prev",
-          "libvirt-tests"
-        ],
-        "nixpkgs": [
-          "libvirt-prev",
-          "libvirt-tests",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1772714211,
-        "narHash": "sha256-VoeFKlozEcwWowkdk4nhxb7DuWjPGINpvpETtiATq8c=",
-        "ref": "gardenlinux",
-        "rev": "1d5e5cf5faf9cd2b60af400ddc76a8377c7f7f5a",
-        "revCount": 54117,
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/cyberus-technology/libvirt"
-      },
-      "original": {
-        "ref": "gardenlinux",
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/cyberus-technology/libvirt"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772822230,
-        "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
+        "lastModified": 1776067740,
+        "narHash": "sha256-B35lpsqnSZwn1Lmz06BpwF7atPgFmUgw1l8KAV3zpVQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1772822230,
-        "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1775595990,
-        "narHash": "sha256-OEf7YqhF9IjJFYZJyuhAypgU+VsRB5lD4DuiMws5Ltc=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "4e92bbcdb030f3b4782be4751dc08e6b6cb6ccf2",
+        "rev": "7e495b747b51f95ae15e74377c5ce1fe69c1765f",
         "type": "github"
       },
       "original": {
@@ -957,8 +793,8 @@
         "edk2-src": "edk2-src",
         "fcntl-tool": "fcntl-tool",
         "libvirt": "libvirt",
-        "libvirt-prev": "libvirt-prev_3",
-        "nixpkgs": "nixpkgs_3"
+        "libvirt-prev": "libvirt-prev_2",
+        "nixpkgs": "nixpkgs"
       }
     },
     "rust-overlay": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
     libvirt.inputs.cloud-hypervisor.follows = "cloud-hypervisor";
     # Break the chain of cyclic dependencies:
     libvirt.inputs.libvirt-tests.inputs.libvirt.follows = "libvirt";
+    libvirt.inputs.libvirt-tests.inputs.libvirt-prev.follows = "libvirt-prev";
     libvirt.inputs.nixpkgs.follows = "nixpkgs";
 
     # cloud-hypervisor.url = "git+file:<path/to/cloud-hypervisor>";
@@ -28,6 +29,11 @@
     # Previous release of libvirt to match cloud-hypervisor's previous version.
     libvirt-prev.url = "git+https://github.com/cyberus-technology/libvirt?ref=refs/tags/gardenlinux-release-26-03-31&submodules=1";
     libvirt-prev.inputs.cloud-hypervisor.follows = "cloud-hypervisor-prev";
+    # Break the chain of cyclic dependencies:
+    libvirt-prev.inputs.libvirt-tests.inputs.libvirt.follows = "libvirt-prev";
+    # TODO: The following line MUST be uncommented once the previous release contains a `flake.nix` with `libvirt-prev` input.
+    # libvirt-prev.inputs.libvirt-tests.inputs.libvirt-prev.follows = "libvirt-prev";
+    libvirt-prev.inputs.nixpkgs.follows = "nixpkgs";
 
     edk2-src.url = "git+https://github.com/cyberus-technology/edk2?ref=gardenlinux&submodules=1";
     edk2-src.flake = false;


### PR DESCRIPTION
In the long run, the flakes should be restructured to avoid the cyclic dependency, but for now this should reduce the `flake.lock` bloat.

Libvirt CI: https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/merge_requests/173