### PR TITLE
tests: Extend Windows boot tests by live migration

### DIFF
--- a/tests/testsuite_windows_cpu_profiles.py
+++ b/tests/testsuite_windows_cpu_profiles.py
@@ -46,13 +46,22 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
 
     def test_windows_boot(self):
         """
-        Test that we do not introduce a regression with respect to booting windows.
+        Test that we do not introduce a regression with respect to
+        booting and migrating windows.
         """
 
         controllerVM.succeed(
             "virsh define /etc/domain-windows-server-sapphire-rapids.xml"
         )
         controllerVM.succeed("virsh start testvm")
+        wait_for_ssh(controllerVM, user="administrator", password="FOO99bar!!")
+        controllerVM.succeed(
+            "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
+        )
+        wait_for_ssh(computeVM, user="administrator", password="FOO99bar!!")
+        computeVM.succeed(
+            "virsh migrate --domain testvm --desturi ch+tcp://controllerVM/session --persistent --live --p2p --parallel --parallel-connections 4"
+        )
         wait_for_ssh(controllerVM, user="administrator", password="FOO99bar!!")
 
 

--- a/tests/testsuite_windows_default.py
+++ b/tests/testsuite_windows_default.py
@@ -46,11 +46,20 @@ class LibvirtTests(LibvirtTestsBase):  # type: ignore
 
     def test_windows_boot(self):
         """
-        Test that we do not introduce a regression with respect to booting windows.
+        Test that we do not introduce a regression with respect to
+        booting and migrating windows.
         """
 
         controllerVM.succeed("virsh define /etc/domain-windows-server.xml")
         controllerVM.succeed("virsh start testvm")
+        wait_for_ssh(controllerVM, user="administrator", password="FOO99bar!!")
+        controllerVM.succeed(
+            "virsh migrate --domain testvm --desturi ch+tcp://computeVM/session --persistent --live --p2p --parallel --parallel-connections 4"
+        )
+        wait_for_ssh(computeVM, user="administrator", password="FOO99bar!!")
+        computeVM.succeed(
+            "virsh migrate --domain testvm --desturi ch+tcp://controllerVM/session --persistent --live --p2p --parallel --parallel-connections 4"
+        )
         wait_for_ssh(controllerVM, user="administrator", password="FOO99bar!!")
 
 


### PR DESCRIPTION
# NOT READY FOR REVIEW YET

We need to ensure that we can live migrate Windows, not only boot it. We therefore extend the simple boot tests by live migration.

TODO:

- [x] I've tested the CPU profile test on our sapphire rapids machine.
- [ ] Add a link to a pipeline